### PR TITLE
Added the ability to provide various configurations to model elements

### DIFF
--- a/ExRam.Gremlinq.Core.Tests/GraphModelTest.cs
+++ b/ExRam.Gremlinq.Core.Tests/GraphModelTest.cs
@@ -217,5 +217,67 @@ namespace ExRam.Gremlinq.Core.Tests
                 .Should()
                 .Be("registrationDate");
         }
+
+        [Fact]
+        public void Configuration_ReadOnly()
+        {
+            var metadata = GraphModel.FromBaseTypes<Vertex, Edge>()
+                .Configure(builder =>
+                {
+                    builder.Element<Person>().ReadOnly(p => p.Name);
+                })
+                .MetadataStore
+                .TryGetPropertyMetadata(typeof(Person), typeof(Person).GetProperty(nameof(Person.Name)));
+
+            Assert.NotNull(metadata);
+            Assert.True(metadata.IsReadOnly);
+            Assert.False(metadata.IsIgnored);
+        }
+
+        [Fact]
+        public void Configuration_Ignored()
+        {
+            var metadata = GraphModel.FromBaseTypes<Vertex, Edge>()
+                .Configure(builder =>
+                {
+                    builder.Element<Person>().Ignored(p => p.Name);
+                })
+                .MetadataStore
+                .TryGetPropertyMetadata(typeof(Person), typeof(Person).GetProperty(nameof(Person.Name)));
+
+            Assert.NotNull(metadata);
+            Assert.True(metadata.IsIgnored);
+            Assert.False(metadata.IsReadOnly);
+        }
+
+        [Fact]
+        public void Configuration_Unconfigured()
+        {
+            var metadata = GraphModel.FromBaseTypes<Vertex, Edge>()
+                .MetadataStore
+                .TryGetPropertyMetadata(typeof(Person), typeof(Person).GetProperty(nameof(Person.Name)));
+
+            Assert.NotNull(metadata);
+            Assert.False(metadata.IsIgnored);
+            Assert.False(metadata.IsReadOnly);
+        }
+
+        [Fact]
+        public void Configuration_Before_Model_Changes()
+        {
+            var metadata = GraphModel.FromBaseTypes<Vertex, Edge>()
+                .Configure(builder =>
+                {
+                    builder.Element<Person>().Ignored(p => p.Name);
+                })
+                .WithCamelcaseLabels()
+                .WithCamelcaseProperties()
+                .MetadataStore
+                .TryGetPropertyMetadata(typeof(Person), typeof(Person).GetProperty(nameof(Person.Name)));
+
+            Assert.NotNull(metadata);
+            Assert.True(metadata.IsIgnored);
+            Assert.False(metadata.IsReadOnly);
+        }
     }
 }

--- a/ExRam.Gremlinq.Core/Extensions/ExpressionExtensions.cs
+++ b/ExRam.Gremlinq.Core/Extensions/ExpressionExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using ExRam.Gremlinq.Core;
 using ExRam.Gremlinq.Core.GraphElements;
@@ -80,97 +82,97 @@ namespace System.Linq.Expressions
                 switch (expression)
                 {
                     case UnaryExpression unaryExpression:
-                    {
-                        if (unaryExpression.NodeType == ExpressionType.Not)
-                            return unaryExpression.Operand.ToGremlinExpression(parameter).Negate();
+                        {
+                            if (unaryExpression.NodeType == ExpressionType.Not)
+                                return unaryExpression.Operand.ToGremlinExpression(parameter).Negate();
 
-                        break;
-                    }
+                            break;
+                        }
                     case MemberExpression memberExpression:
-                    {
-                        if (memberExpression.Member is PropertyInfo property && property.PropertyType == typeof(bool))
-                            return new TerminalGremlinExpression(parameter, memberExpression, new P.Eq(true));
+                        {
+                            if (memberExpression.Member is PropertyInfo property && property.PropertyType == typeof(bool))
+                                return new TerminalGremlinExpression(parameter, memberExpression, new P.Eq(true));
 
-                        break;
-                    }
+                            break;
+                        }
                     case BinaryExpression binaryExpression:
-                    {
-                        if (binaryExpression.NodeType == ExpressionType.AndAlso)
-                            return new AndGremlinExpression(parameter, binaryExpression.Left.StripConvert().ToGremlinExpression(parameter), binaryExpression.Right.StripConvert().ToGremlinExpression(parameter));
+                        {
+                            if (binaryExpression.NodeType == ExpressionType.AndAlso)
+                                return new AndGremlinExpression(parameter, binaryExpression.Left.StripConvert().ToGremlinExpression(parameter), binaryExpression.Right.StripConvert().ToGremlinExpression(parameter));
 
-                        if (binaryExpression.NodeType == ExpressionType.OrElse)
-                            return new OrGremlinExpression(parameter, binaryExpression.Left.StripConvert().ToGremlinExpression(parameter), binaryExpression.Right.StripConvert().ToGremlinExpression(parameter));
+                            if (binaryExpression.NodeType == ExpressionType.OrElse)
+                                return new OrGremlinExpression(parameter, binaryExpression.Left.StripConvert().ToGremlinExpression(parameter), binaryExpression.Right.StripConvert().ToGremlinExpression(parameter));
 
-                        return binaryExpression.Right.HasExpressionInMemberChain(parameter)
-                            ? new TerminalGremlinExpression(parameter, binaryExpression.Right.StripConvert(), binaryExpression.NodeType.Switch().ToP(binaryExpression.Left.GetValue()))
-                            : new TerminalGremlinExpression(parameter, binaryExpression.Left.StripConvert(), binaryExpression.NodeType.ToP(binaryExpression.Right.GetValue()));
-                    }
+                            return binaryExpression.Right.HasExpressionInMemberChain(parameter)
+                                ? new TerminalGremlinExpression(parameter, binaryExpression.Right.StripConvert(), binaryExpression.NodeType.Switch().ToP(binaryExpression.Left.GetValue()))
+                                : new TerminalGremlinExpression(parameter, binaryExpression.Left.StripConvert(), binaryExpression.NodeType.ToP(binaryExpression.Right.GetValue()));
+                        }
                     case MethodCallExpression methodCallExpression:
-                    {
-                        var methodInfo = methodCallExpression.Method;
-
-                        if (methodInfo.IsEnumerableAny())
                         {
-                            if (methodCallExpression.Arguments[0] is MethodCallExpression previousExpression && previousExpression.Method.IsEnumerableIntersect())
+                            var methodInfo = methodCallExpression.Method;
+
+                            if (methodInfo.IsEnumerableAny())
                             {
-                                if (previousExpression.Arguments[0] is MemberExpression sourceMember)
-                                    return new TerminalGremlinExpression(parameter, sourceMember, previousExpression.Arguments[1].ToPWithin());
-
-                                if (previousExpression.Arguments[1] is MemberExpression argument && argument.Expression == parameter)
-                                    return new TerminalGremlinExpression(parameter, argument, previousExpression.Arguments[0].ToPWithin());
-                            }
-                            else
-                                return new TerminalGremlinExpression(parameter, methodCallExpression.Arguments[0], new P.Neq(null));
-                        }
-                        else if (methodInfo.IsEnumerableContains())
-                        {
-                            if (methodCallExpression.Arguments[0] is MemberExpression sourceMember && sourceMember.Expression == parameter)
-                                return new TerminalGremlinExpression(parameter, sourceMember, new P.Eq(methodCallExpression.Arguments[1].GetValue()));
-
-                            if (methodCallExpression.Arguments[1] is MemberExpression argument && argument.Expression == parameter)
-                                return new TerminalGremlinExpression(parameter, argument, methodCallExpression.Arguments[0].ToPWithin());
-                        }
-                        else if (methodInfo.IsStringStartsWith())
-                        {
-                            if (methodCallExpression.Arguments[0] is MemberExpression argumentExpression)
-                            {
-                                if (methodCallExpression.Object.GetValue() is string stringValue)
+                                if (methodCallExpression.Arguments[0] is MethodCallExpression previousExpression && previousExpression.Method.IsEnumerableIntersect())
                                 {
-                                    return new TerminalGremlinExpression(
-                                        parameter,
-                                        argumentExpression,
-                                        new P.Within(Enumerable
-                                            .Range(0, stringValue.Length + 1)
-                                            .Select(i => stringValue.Substring(0, i))
-                                            .ToArray<object>()));
+                                    if (previousExpression.Arguments[0] is MemberExpression sourceMember)
+                                        return new TerminalGremlinExpression(parameter, sourceMember, previousExpression.Arguments[1].ToPWithin());
+
+                                    if (previousExpression.Arguments[1] is MemberExpression argument && argument.Expression == parameter)
+                                        return new TerminalGremlinExpression(parameter, argument, previousExpression.Arguments[0].ToPWithin());
                                 }
+                                else
+                                    return new TerminalGremlinExpression(parameter, methodCallExpression.Arguments[0], new P.Neq(null));
                             }
-                            else if (methodCallExpression.Object is MemberExpression memberExpression)
+                            else if (methodInfo.IsEnumerableContains())
                             {
-                                if (methodCallExpression.Arguments[0].GetValue() is string lowerBound)
+                                if (methodCallExpression.Arguments[0] is MemberExpression sourceMember && sourceMember.Expression == parameter)
+                                    return new TerminalGremlinExpression(parameter, sourceMember, new P.Eq(methodCallExpression.Arguments[1].GetValue()));
+
+                                if (methodCallExpression.Arguments[1] is MemberExpression argument && argument.Expression == parameter)
+                                    return new TerminalGremlinExpression(parameter, argument, methodCallExpression.Arguments[0].ToPWithin());
+                            }
+                            else if (methodInfo.IsStringStartsWith())
+                            {
+                                if (methodCallExpression.Arguments[0] is MemberExpression argumentExpression)
                                 {
-                                    string upperBound;
-
-                                    if (lowerBound.Length == 0)
-                                        return new TerminalGremlinExpression(parameter, memberExpression, P.True);
-
-                                    if (lowerBound[lowerBound.Length - 1] == char.MaxValue)
-                                        upperBound = lowerBound + char.MinValue;
-                                    else
+                                    if (methodCallExpression.Object.GetValue() is string stringValue)
                                     {
-                                        var upperBoundChars = lowerBound.ToCharArray();
-
-                                        upperBoundChars[upperBoundChars.Length - 1]++;
-                                        upperBound = new string(upperBoundChars);
+                                        return new TerminalGremlinExpression(
+                                            parameter,
+                                            argumentExpression,
+                                            new P.Within(Enumerable
+                                                .Range(0, stringValue.Length + 1)
+                                                .Select(i => stringValue.Substring(0, i))
+                                                .ToArray<object>()));
                                     }
+                                }
+                                else if (methodCallExpression.Object is MemberExpression memberExpression)
+                                {
+                                    if (methodCallExpression.Arguments[0].GetValue() is string lowerBound)
+                                    {
+                                        string upperBound;
 
-                                    return new TerminalGremlinExpression(parameter, memberExpression, new P.Between(lowerBound, upperBound));
+                                        if (lowerBound.Length == 0)
+                                            return new TerminalGremlinExpression(parameter, memberExpression, P.True);
+
+                                        if (lowerBound[lowerBound.Length - 1] == char.MaxValue)
+                                            upperBound = lowerBound + char.MinValue;
+                                        else
+                                        {
+                                            var upperBoundChars = lowerBound.ToCharArray();
+
+                                            upperBoundChars[upperBoundChars.Length - 1]++;
+                                            upperBound = new string(upperBoundChars);
+                                        }
+
+                                        return new TerminalGremlinExpression(parameter, memberExpression, new P.Between(lowerBound, upperBound));
+                                    }
                                 }
                             }
-                        }
 
-                        break;
-                    }
+                            break;
+                        }
                 }
             }
             catch (ExpressionNotSupportedException ex)
@@ -187,6 +189,99 @@ namespace System.Linq.Expressions
                 return new P.Within(enumerable.Cast<object>().ToArray());
 
             throw new ExpressionNotSupportedException(expression);
+        }
+
+        public static PropertyInfo GetPropertyAccess(this LambdaExpression propertyAccessExpression)
+        {
+            Debug.Assert(propertyAccessExpression.Parameters.Count == 1);
+
+            var parameterExpression = propertyAccessExpression.Parameters.Single();
+            var propertyInfo = parameterExpression.MatchSimplePropertyAccess(propertyAccessExpression.Body);
+
+            if (propertyInfo == null)
+            {
+                throw new ArgumentException(
+                    "Invalid property access expression",
+                    nameof(propertyAccessExpression));
+            }
+
+            var declaringType = propertyInfo.DeclaringType;
+            var parameterType = parameterExpression.Type;
+
+            if (declaringType != null
+                && declaringType != parameterType
+                && declaringType.GetTypeInfo().IsInterface
+                && declaringType.GetTypeInfo().IsAssignableFrom(parameterType.GetTypeInfo()))
+            {
+                var propertyGetter = propertyInfo.GetMethod;
+                var interfaceMapping = parameterType.GetTypeInfo().GetRuntimeInterfaceMap(declaringType);
+                var index = Array.FindIndex(interfaceMapping.InterfaceMethods, p => propertyGetter.Equals(p));
+                var targetMethod = interfaceMapping.TargetMethods[index];
+                foreach (var runtimeProperty in parameterType.GetRuntimeProperties())
+                {
+                    if (targetMethod.Equals(runtimeProperty.GetMethod))
+                    {
+                        return runtimeProperty;
+                    }
+                }
+            }
+
+            return propertyInfo;
+        }
+
+        private static PropertyInfo MatchSimplePropertyAccess(
+           this Expression parameterExpression, Expression propertyAccessExpression)
+        {
+            var propertyInfos = MatchPropertyAccess(parameterExpression, propertyAccessExpression);
+
+            return propertyInfos?.Count == 1 ? propertyInfos[0] : null;
+        }
+
+        private static IReadOnlyList<PropertyInfo> MatchPropertyAccess(
+            this Expression parameterExpression, Expression propertyAccessExpression)
+        {
+            var propertyInfos = new List<PropertyInfo>();
+
+            MemberExpression memberExpression;
+
+            do
+            {
+                memberExpression = RemoveTypeAs(propertyAccessExpression.RemoveConvert()) as MemberExpression;
+
+                if (!(memberExpression?.Member is PropertyInfo propertyInfo))
+                {
+                    return null;
+                }
+
+                propertyInfos.Insert(0, propertyInfo);
+
+                propertyAccessExpression = memberExpression.Expression;
+            }
+            while (RemoveTypeAs(memberExpression.Expression.RemoveConvert()) != parameterExpression);
+
+            return propertyInfos;
+        }
+
+        private static Expression RemoveTypeAs(this Expression expression)
+        {
+            while ((expression?.NodeType == ExpressionType.TypeAs))
+            {
+                expression = ((UnaryExpression)expression.RemoveConvert()).Operand;
+            }
+
+            return expression;
+        }
+
+        private static Expression RemoveConvert(this Expression expression)
+        {
+            while (expression != null
+                   && (expression.NodeType == ExpressionType.Convert
+                       || expression.NodeType == ExpressionType.ConvertChecked))
+            {
+                expression = RemoveConvert(((UnaryExpression)expression).Operand);
+            }
+
+            return expression;
         }
     }
 }

--- a/ExRam.Gremlinq.Core/Models/IGraphModel.cs
+++ b/ExRam.Gremlinq.Core/Models/IGraphModel.cs
@@ -9,7 +9,10 @@ namespace ExRam.Gremlinq.Core
 
         IGraphElementModel VerticesModel { get; }
         IGraphElementModel EdgesModel { get; }
+        IMetadataStore MetadataStore { get; }
 
         object GetIdentifier(Expression expression);
+
+        IGraphModel Configure(Action<IElementBuilder> action);
     }
 }

--- a/ExRam.Gremlinq.Core/Models/Metadata/ElementBuilder.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/ElementBuilder.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExRam.Gremlinq.Core
+{
+    internal class ElementBuilder : IElementBuilder
+    {
+        private readonly IMetadataStore _metadataStore;
+
+        public ElementBuilder(IMetadataStore metadataStore)
+        {
+            _metadataStore = metadataStore;
+        }
+
+        public IMetadataBuilder<TElement> Element<TElement>()
+        {
+            return new MetadataBuilder<TElement>(_metadataStore);
+        }
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/IElementBuilder.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/IElementBuilder.cs
@@ -1,0 +1,7 @@
+﻿namespace ExRam.Gremlinq.Core
+{
+    public interface IElementBuilder
+    {
+        IMetadataBuilder<TElement> Element<TElement>();
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/IMetadataBuilder.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/IMetadataBuilder.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace ExRam.Gremlinq.Core
+{
+    public interface IMetadataBuilder<TElement>
+    {
+        IMetadataBuilder<TElement> ReadOnly<TProperty>(Expression<Func<TElement, TProperty>> propertyExpression);
+
+        IMetadataBuilder<TElement> Ignored<TProperty>(Expression<Func<TElement, TProperty>> propertyExpression);
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/IMetadataStore.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/IMetadataStore.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Reflection;
+
+namespace ExRam.Gremlinq.Core
+{
+    public interface IMetadataStore : ICloneable
+    {
+        PropertyMetadata TryGetPropertyMetadata(Type elementType, PropertyInfo property);
+
+        void UpdatePropertyMetadata(Type type, PropertyInfo propertyInfo, Action<PropertyMetadata> updateAction);
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/MetadataBuilder.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/MetadataBuilder.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace ExRam.Gremlinq.Core
+{
+    internal class MetadataBuilder<TElement> : IMetadataBuilder<TElement>
+    {
+        private IMetadataStore _metadataStore;
+
+        public MetadataBuilder(IMetadataStore metadataStore)
+        {
+            _metadataStore = metadataStore;
+        }
+
+        public IMetadataBuilder<TElement> ReadOnly<TProperty>(Expression<Func<TElement, TProperty>> propertyExpression)
+        {
+            UpdateMetadata(typeof(TElement), propertyExpression, (metadata) => metadata.IsReadOnly = true);
+
+            return this;
+        }
+
+        public IMetadataBuilder<TElement> Ignored<TProperty>(Expression<Func<TElement, TProperty>> propertyExpression)
+        {
+            UpdateMetadata(typeof(TElement), propertyExpression, (metadata) => metadata.IsIgnored = true);
+
+            return this;
+        }
+
+        private void UpdateMetadata<TProperty>(Type type, Expression<Func<TElement, TProperty>> propertyExpression, Action<PropertyMetadata> action)
+        {
+            var pi = propertyExpression.GetPropertyAccess();
+
+            _metadataStore.UpdatePropertyMetadata(type, pi, action);
+        }
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/MetadataStore.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/MetadataStore.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace ExRam.Gremlinq.Core
+{
+    public class MetadataStore : IMetadataStore
+    {
+        private readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyMetadata>> _propertyMetadataDictionary;
+
+        public MetadataStore()
+        {
+            _propertyMetadataDictionary = new ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyMetadata>>();
+        }
+
+        internal MetadataStore(ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyMetadata>> source)
+        {
+            _propertyMetadataDictionary = source;
+        }
+
+        public void UpdatePropertyMetadata(Type type, PropertyInfo propertyInfo, Action<PropertyMetadata> updateAction)
+        {
+            var typeDictionary = _propertyMetadataDictionary.GetOrAdd(type, new ConcurrentDictionary<string, PropertyMetadata>());
+
+            var metadata = typeDictionary.GetOrAdd(propertyInfo.Name, new PropertyMetadata());
+
+            updateAction(metadata);
+        }
+
+        public PropertyMetadata TryGetPropertyMetadata(Type elementType, PropertyInfo property)
+        {
+            PropertyMetadata retVal = default;
+
+            if (_propertyMetadataDictionary.TryGetValue(elementType, out var typeDictionary))
+            {
+                if (typeDictionary.TryGetValue(property.Name, out var metadata))
+                {
+                    // Treat as immutable
+                    retVal = new PropertyMetadata(metadata);
+                }
+            }
+
+            return retVal ?? new PropertyMetadata();
+        }
+
+        public object Clone()
+        {
+            var copy = new ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyMetadata>>();
+
+            foreach (var typeKey in _propertyMetadataDictionary.Keys)
+            {
+                var propertyCopy = new ConcurrentDictionary<string, PropertyMetadata>();
+                copy.TryAdd(typeKey, propertyCopy);
+
+                var propertyDictionary = _propertyMetadataDictionary[typeKey];
+
+                foreach (var propertyKey in propertyDictionary.Keys)
+                {
+                    propertyCopy.TryAdd(propertyKey, new PropertyMetadata(propertyDictionary[propertyKey]));
+                }
+            }
+
+            return new MetadataStore(copy);
+        }
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/PropertyMetadata.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/PropertyMetadata.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExRam.Gremlinq.Core
+{
+    public class PropertyMetadata
+    {
+        public bool IsReadOnly { get; internal set; }
+
+        public bool IsIgnored { get; internal set; }
+
+        public PropertyMetadata()
+        {
+
+        }
+
+        public PropertyMetadata(PropertyMetadata source)
+        {
+            IsReadOnly = source.IsReadOnly;
+            IsIgnored = source.IsIgnored;
+        }
+    }
+}


### PR DESCRIPTION
Continuation of PR #11.

I added the ability to provide configuration for the elements and properties that make up a model. For example:
```
 g
    .WithLogger(_logger)
    .WithModel(GraphModel.Dynamic()
        .WithCamelcaseLabels()
        .WithCamelcaseProperties()
        .Configure(builder =>
            {
                builder.Element<Person>()
                    .ReadOnly(p => p.Id)
                    .Ignore(p => p.SomethingNotPersisted);
            }))
    .WithCosmosDbRemote(...);
```
Let me know if you'd like any updates and I'll be happy to make the changes.