### PR TITLE
Add Update and Replace methods to support CRUD operations

### DIFF
--- a/ExRam.Gremlinq.Core.Tests/GraphModelTest.cs
+++ b/ExRam.Gremlinq.Core.Tests/GraphModelTest.cs
@@ -217,5 +217,67 @@ namespace ExRam.Gremlinq.Core.Tests
                 .Should()
                 .Be("registrationDate");
         }
+
+        [Fact]
+        public void Configuration_ReadOnly()
+        {
+            var metadata = GraphModel.FromBaseTypes<Vertex, Edge>()
+                .Configure(builder =>
+                {
+                    builder.Element<Person>().ReadOnly(p => p.Name);
+                })
+                .MetadataStore
+                .TryGetPropertyMetadata(typeof(Person), typeof(Person).GetProperty(nameof(Person.Name)));
+
+            Assert.NotNull(metadata);
+            Assert.True(metadata.IsReadOnly);
+            Assert.False(metadata.IsIgnored);
+        }
+
+        [Fact]
+        public void Configuration_Ignored()
+        {
+            var metadata = GraphModel.FromBaseTypes<Vertex, Edge>()
+                .Configure(builder =>
+                {
+                    builder.Element<Person>().Ignored(p => p.Name);
+                })
+                .MetadataStore
+                .TryGetPropertyMetadata(typeof(Person), typeof(Person).GetProperty(nameof(Person.Name)));
+
+            Assert.NotNull(metadata);
+            Assert.True(metadata.IsIgnored);
+            Assert.False(metadata.IsReadOnly);
+        }
+
+        [Fact]
+        public void Configuration_Unconfigured()
+        {
+            var metadata = GraphModel.FromBaseTypes<Vertex, Edge>()
+                .MetadataStore
+                .TryGetPropertyMetadata(typeof(Person), typeof(Person).GetProperty(nameof(Person.Name)));
+
+            Assert.NotNull(metadata);
+            Assert.False(metadata.IsIgnored);
+            Assert.False(metadata.IsReadOnly);
+        }
+
+        [Fact]
+        public void Configuration_Before_Model_Changes()
+        {
+            var metadata = GraphModel.FromBaseTypes<Vertex, Edge>()
+                .Configure(builder =>
+                {
+                    builder.Element<Person>().Ignored(p => p.Name);
+                })
+                .WithCamelcaseLabels()
+                .WithCamelcaseProperties()
+                .MetadataStore
+                .TryGetPropertyMetadata(typeof(Person), typeof(Person).GetProperty(nameof(Person.Name)));
+
+            Assert.NotNull(metadata);
+            Assert.True(metadata.IsIgnored);
+            Assert.False(metadata.IsReadOnly);
+        }
     }
 }

--- a/ExRam.Gremlinq.Core/Extensions/ExpressionExtensions.cs
+++ b/ExRam.Gremlinq.Core/Extensions/ExpressionExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using ExRam.Gremlinq.Core;
 using ExRam.Gremlinq.Core.GraphElements;
@@ -80,97 +82,97 @@ namespace System.Linq.Expressions
                 switch (expression)
                 {
                     case UnaryExpression unaryExpression:
-                    {
-                        if (unaryExpression.NodeType == ExpressionType.Not)
-                            return unaryExpression.Operand.ToGremlinExpression(parameter).Negate();
+                        {
+                            if (unaryExpression.NodeType == ExpressionType.Not)
+                                return unaryExpression.Operand.ToGremlinExpression(parameter).Negate();
 
-                        break;
-                    }
+                            break;
+                        }
                     case MemberExpression memberExpression:
-                    {
-                        if (memberExpression.Member is PropertyInfo property && property.PropertyType == typeof(bool))
-                            return new TerminalGremlinExpression(parameter, memberExpression, new P.Eq(true));
+                        {
+                            if (memberExpression.Member is PropertyInfo property && property.PropertyType == typeof(bool))
+                                return new TerminalGremlinExpression(parameter, memberExpression, new P.Eq(true));
 
-                        break;
-                    }
+                            break;
+                        }
                     case BinaryExpression binaryExpression:
-                    {
-                        if (binaryExpression.NodeType == ExpressionType.AndAlso)
-                            return new AndGremlinExpression(parameter, binaryExpression.Left.StripConvert().ToGremlinExpression(parameter), binaryExpression.Right.StripConvert().ToGremlinExpression(parameter));
+                        {
+                            if (binaryExpression.NodeType == ExpressionType.AndAlso)
+                                return new AndGremlinExpression(parameter, binaryExpression.Left.StripConvert().ToGremlinExpression(parameter), binaryExpression.Right.StripConvert().ToGremlinExpression(parameter));
 
-                        if (binaryExpression.NodeType == ExpressionType.OrElse)
-                            return new OrGremlinExpression(parameter, binaryExpression.Left.StripConvert().ToGremlinExpression(parameter), binaryExpression.Right.StripConvert().ToGremlinExpression(parameter));
+                            if (binaryExpression.NodeType == ExpressionType.OrElse)
+                                return new OrGremlinExpression(parameter, binaryExpression.Left.StripConvert().ToGremlinExpression(parameter), binaryExpression.Right.StripConvert().ToGremlinExpression(parameter));
 
-                        return binaryExpression.Right.HasExpressionInMemberChain(parameter)
-                            ? new TerminalGremlinExpression(parameter, binaryExpression.Right.StripConvert(), binaryExpression.NodeType.Switch().ToP(binaryExpression.Left.GetValue()))
-                            : new TerminalGremlinExpression(parameter, binaryExpression.Left.StripConvert(), binaryExpression.NodeType.ToP(binaryExpression.Right.GetValue()));
-                    }
+                            return binaryExpression.Right.HasExpressionInMemberChain(parameter)
+                                ? new TerminalGremlinExpression(parameter, binaryExpression.Right.StripConvert(), binaryExpression.NodeType.Switch().ToP(binaryExpression.Left.GetValue()))
+                                : new TerminalGremlinExpression(parameter, binaryExpression.Left.StripConvert(), binaryExpression.NodeType.ToP(binaryExpression.Right.GetValue()));
+                        }
                     case MethodCallExpression methodCallExpression:
-                    {
-                        var methodInfo = methodCallExpression.Method;
-
-                        if (methodInfo.IsEnumerableAny())
                         {
-                            if (methodCallExpression.Arguments[0] is MethodCallExpression previousExpression && previousExpression.Method.IsEnumerableIntersect())
+                            var methodInfo = methodCallExpression.Method;
+
+                            if (methodInfo.IsEnumerableAny())
                             {
-                                if (previousExpression.Arguments[0] is MemberExpression sourceMember)
-                                    return new TerminalGremlinExpression(parameter, sourceMember, previousExpression.Arguments[1].ToPWithin());
-
-                                if (previousExpression.Arguments[1] is MemberExpression argument && argument.Expression == parameter)
-                                    return new TerminalGremlinExpression(parameter, argument, previousExpression.Arguments[0].ToPWithin());
-                            }
-                            else
-                                return new TerminalGremlinExpression(parameter, methodCallExpression.Arguments[0], new P.Neq(null));
-                        }
-                        else if (methodInfo.IsEnumerableContains())
-                        {
-                            if (methodCallExpression.Arguments[0] is MemberExpression sourceMember && sourceMember.Expression == parameter)
-                                return new TerminalGremlinExpression(parameter, sourceMember, new P.Eq(methodCallExpression.Arguments[1].GetValue()));
-
-                            if (methodCallExpression.Arguments[1] is MemberExpression argument && argument.Expression == parameter)
-                                return new TerminalGremlinExpression(parameter, argument, methodCallExpression.Arguments[0].ToPWithin());
-                        }
-                        else if (methodInfo.IsStringStartsWith())
-                        {
-                            if (methodCallExpression.Arguments[0] is MemberExpression argumentExpression)
-                            {
-                                if (methodCallExpression.Object.GetValue() is string stringValue)
+                                if (methodCallExpression.Arguments[0] is MethodCallExpression previousExpression && previousExpression.Method.IsEnumerableIntersect())
                                 {
-                                    return new TerminalGremlinExpression(
-                                        parameter,
-                                        argumentExpression,
-                                        new P.Within(Enumerable
-                                            .Range(0, stringValue.Length + 1)
-                                            .Select(i => stringValue.Substring(0, i))
-                                            .ToArray<object>()));
+                                    if (previousExpression.Arguments[0] is MemberExpression sourceMember)
+                                        return new TerminalGremlinExpression(parameter, sourceMember, previousExpression.Arguments[1].ToPWithin());
+
+                                    if (previousExpression.Arguments[1] is MemberExpression argument && argument.Expression == parameter)
+                                        return new TerminalGremlinExpression(parameter, argument, previousExpression.Arguments[0].ToPWithin());
                                 }
+                                else
+                                    return new TerminalGremlinExpression(parameter, methodCallExpression.Arguments[0], new P.Neq(null));
                             }
-                            else if (methodCallExpression.Object is MemberExpression memberExpression)
+                            else if (methodInfo.IsEnumerableContains())
                             {
-                                if (methodCallExpression.Arguments[0].GetValue() is string lowerBound)
+                                if (methodCallExpression.Arguments[0] is MemberExpression sourceMember && sourceMember.Expression == parameter)
+                                    return new TerminalGremlinExpression(parameter, sourceMember, new P.Eq(methodCallExpression.Arguments[1].GetValue()));
+
+                                if (methodCallExpression.Arguments[1] is MemberExpression argument && argument.Expression == parameter)
+                                    return new TerminalGremlinExpression(parameter, argument, methodCallExpression.Arguments[0].ToPWithin());
+                            }
+                            else if (methodInfo.IsStringStartsWith())
+                            {
+                                if (methodCallExpression.Arguments[0] is MemberExpression argumentExpression)
                                 {
-                                    string upperBound;
-
-                                    if (lowerBound.Length == 0)
-                                        return new TerminalGremlinExpression(parameter, memberExpression, P.True);
-
-                                    if (lowerBound[lowerBound.Length - 1] == char.MaxValue)
-                                        upperBound = lowerBound + char.MinValue;
-                                    else
+                                    if (methodCallExpression.Object.GetValue() is string stringValue)
                                     {
-                                        var upperBoundChars = lowerBound.ToCharArray();
-
-                                        upperBoundChars[upperBoundChars.Length - 1]++;
-                                        upperBound = new string(upperBoundChars);
+                                        return new TerminalGremlinExpression(
+                                            parameter,
+                                            argumentExpression,
+                                            new P.Within(Enumerable
+                                                .Range(0, stringValue.Length + 1)
+                                                .Select(i => stringValue.Substring(0, i))
+                                                .ToArray<object>()));
                                     }
+                                }
+                                else if (methodCallExpression.Object is MemberExpression memberExpression)
+                                {
+                                    if (methodCallExpression.Arguments[0].GetValue() is string lowerBound)
+                                    {
+                                        string upperBound;
 
-                                    return new TerminalGremlinExpression(parameter, memberExpression, new P.Between(lowerBound, upperBound));
+                                        if (lowerBound.Length == 0)
+                                            return new TerminalGremlinExpression(parameter, memberExpression, P.True);
+
+                                        if (lowerBound[lowerBound.Length - 1] == char.MaxValue)
+                                            upperBound = lowerBound + char.MinValue;
+                                        else
+                                        {
+                                            var upperBoundChars = lowerBound.ToCharArray();
+
+                                            upperBoundChars[upperBoundChars.Length - 1]++;
+                                            upperBound = new string(upperBoundChars);
+                                        }
+
+                                        return new TerminalGremlinExpression(parameter, memberExpression, new P.Between(lowerBound, upperBound));
+                                    }
                                 }
                             }
-                        }
 
-                        break;
-                    }
+                            break;
+                        }
                 }
             }
             catch (ExpressionNotSupportedException ex)
@@ -187,6 +189,99 @@ namespace System.Linq.Expressions
                 return new P.Within(enumerable.Cast<object>().ToArray());
 
             throw new ExpressionNotSupportedException(expression);
+        }
+
+        public static PropertyInfo GetPropertyAccess(this LambdaExpression propertyAccessExpression)
+        {
+            Debug.Assert(propertyAccessExpression.Parameters.Count == 1);
+
+            var parameterExpression = propertyAccessExpression.Parameters.Single();
+            var propertyInfo = parameterExpression.MatchSimplePropertyAccess(propertyAccessExpression.Body);
+
+            if (propertyInfo == null)
+            {
+                throw new ArgumentException(
+                    "Invalid property access expression",
+                    nameof(propertyAccessExpression));
+            }
+
+            var declaringType = propertyInfo.DeclaringType;
+            var parameterType = parameterExpression.Type;
+
+            if (declaringType != null
+                && declaringType != parameterType
+                && declaringType.GetTypeInfo().IsInterface
+                && declaringType.GetTypeInfo().IsAssignableFrom(parameterType.GetTypeInfo()))
+            {
+                var propertyGetter = propertyInfo.GetMethod;
+                var interfaceMapping = parameterType.GetTypeInfo().GetRuntimeInterfaceMap(declaringType);
+                var index = Array.FindIndex(interfaceMapping.InterfaceMethods, p => propertyGetter.Equals(p));
+                var targetMethod = interfaceMapping.TargetMethods[index];
+                foreach (var runtimeProperty in parameterType.GetRuntimeProperties())
+                {
+                    if (targetMethod.Equals(runtimeProperty.GetMethod))
+                    {
+                        return runtimeProperty;
+                    }
+                }
+            }
+
+            return propertyInfo;
+        }
+
+        private static PropertyInfo MatchSimplePropertyAccess(
+           this Expression parameterExpression, Expression propertyAccessExpression)
+        {
+            var propertyInfos = MatchPropertyAccess(parameterExpression, propertyAccessExpression);
+
+            return propertyInfos?.Count == 1 ? propertyInfos[0] : null;
+        }
+
+        private static IReadOnlyList<PropertyInfo> MatchPropertyAccess(
+            this Expression parameterExpression, Expression propertyAccessExpression)
+        {
+            var propertyInfos = new List<PropertyInfo>();
+
+            MemberExpression memberExpression;
+
+            do
+            {
+                memberExpression = RemoveTypeAs(propertyAccessExpression.RemoveConvert()) as MemberExpression;
+
+                if (!(memberExpression?.Member is PropertyInfo propertyInfo))
+                {
+                    return null;
+                }
+
+                propertyInfos.Insert(0, propertyInfo);
+
+                propertyAccessExpression = memberExpression.Expression;
+            }
+            while (RemoveTypeAs(memberExpression.Expression.RemoveConvert()) != parameterExpression);
+
+            return propertyInfos;
+        }
+
+        private static Expression RemoveTypeAs(this Expression expression)
+        {
+            while ((expression?.NodeType == ExpressionType.TypeAs))
+            {
+                expression = ((UnaryExpression)expression.RemoveConvert()).Operand;
+            }
+
+            return expression;
+        }
+
+        private static Expression RemoveConvert(this Expression expression)
+        {
+            while (expression != null
+                   && (expression.NodeType == ExpressionType.Convert
+                       || expression.NodeType == ExpressionType.ConvertChecked))
+            {
+                expression = RemoveConvert(((UnaryExpression)expression).Operand);
+            }
+
+            return expression;
         }
     }
 }

--- a/ExRam.Gremlinq.Core/Models/IGraphModel.cs
+++ b/ExRam.Gremlinq.Core/Models/IGraphModel.cs
@@ -9,7 +9,10 @@ namespace ExRam.Gremlinq.Core
 
         IGraphElementModel VerticesModel { get; }
         IGraphElementModel EdgesModel { get; }
+        IMetadataStore MetadataStore { get; }
 
         object GetIdentifier(Expression expression);
+
+        IGraphModel Configure(Action<IElementBuilder> action);
     }
 }

--- a/ExRam.Gremlinq.Core/Models/Metadata/ElementBuilder.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/ElementBuilder.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExRam.Gremlinq.Core
+{
+    internal class ElementBuilder : IElementBuilder
+    {
+        private readonly IMetadataStore _metadataStore;
+
+        public ElementBuilder(IMetadataStore metadataStore)
+        {
+            _metadataStore = metadataStore;
+        }
+
+        public IMetadataBuilder<TElement> Element<TElement>()
+        {
+            return new MetadataBuilder<TElement>(_metadataStore);
+        }
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/IElementBuilder.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/IElementBuilder.cs
@@ -1,0 +1,7 @@
+﻿namespace ExRam.Gremlinq.Core
+{
+    public interface IElementBuilder
+    {
+        IMetadataBuilder<TElement> Element<TElement>();
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/IMetadataBuilder.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/IMetadataBuilder.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace ExRam.Gremlinq.Core
+{
+    public interface IMetadataBuilder<TElement>
+    {
+        IMetadataBuilder<TElement> ReadOnly<TProperty>(Expression<Func<TElement, TProperty>> propertyExpression);
+
+        IMetadataBuilder<TElement> Ignored<TProperty>(Expression<Func<TElement, TProperty>> propertyExpression);
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/IMetadataStore.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/IMetadataStore.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Reflection;
+
+namespace ExRam.Gremlinq.Core
+{
+    public interface IMetadataStore : ICloneable
+    {
+        PropertyMetadata TryGetPropertyMetadata(Type elementType, PropertyInfo property);
+
+        void UpdatePropertyMetadata(Type type, PropertyInfo propertyInfo, Action<PropertyMetadata> updateAction);
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/MetadataBuilder.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/MetadataBuilder.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace ExRam.Gremlinq.Core
+{
+    internal class MetadataBuilder<TElement> : IMetadataBuilder<TElement>
+    {
+        private IMetadataStore _metadataStore;
+
+        public MetadataBuilder(IMetadataStore metadataStore)
+        {
+            _metadataStore = metadataStore;
+        }
+
+        public IMetadataBuilder<TElement> ReadOnly<TProperty>(Expression<Func<TElement, TProperty>> propertyExpression)
+        {
+            UpdateMetadata(typeof(TElement), propertyExpression, (metadata) => metadata.IsReadOnly = true);
+
+            return this;
+        }
+
+        public IMetadataBuilder<TElement> Ignored<TProperty>(Expression<Func<TElement, TProperty>> propertyExpression)
+        {
+            UpdateMetadata(typeof(TElement), propertyExpression, (metadata) => metadata.IsIgnored = true);
+
+            return this;
+        }
+
+        private void UpdateMetadata<TProperty>(Type type, Expression<Func<TElement, TProperty>> propertyExpression, Action<PropertyMetadata> action)
+        {
+            var pi = propertyExpression.GetPropertyAccess();
+
+            _metadataStore.UpdatePropertyMetadata(type, pi, action);
+        }
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/MetadataStore.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/MetadataStore.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace ExRam.Gremlinq.Core
+{
+    public class MetadataStore : IMetadataStore
+    {
+        private readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyMetadata>> _propertyMetadataDictionary;
+
+        public MetadataStore()
+        {
+            _propertyMetadataDictionary = new ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyMetadata>>();
+        }
+
+        internal MetadataStore(ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyMetadata>> source)
+        {
+            _propertyMetadataDictionary = source;
+        }
+
+        public void UpdatePropertyMetadata(Type type, PropertyInfo propertyInfo, Action<PropertyMetadata> updateAction)
+        {
+            var typeDictionary = _propertyMetadataDictionary.GetOrAdd(type, new ConcurrentDictionary<string, PropertyMetadata>());
+
+            var metadata = typeDictionary.GetOrAdd(propertyInfo.Name, new PropertyMetadata());
+
+            updateAction(metadata);
+        }
+
+        public PropertyMetadata TryGetPropertyMetadata(Type elementType, PropertyInfo property)
+        {
+            PropertyMetadata retVal = default;
+
+            if (_propertyMetadataDictionary.TryGetValue(elementType, out var typeDictionary))
+            {
+                if (typeDictionary.TryGetValue(property.Name, out var metadata))
+                {
+                    // Treat as immutable
+                    retVal = new PropertyMetadata(metadata);
+                }
+            }
+
+            return retVal ?? new PropertyMetadata();
+        }
+
+        public object Clone()
+        {
+            var copy = new ConcurrentDictionary<Type, ConcurrentDictionary<string, PropertyMetadata>>();
+
+            foreach (var typeKey in _propertyMetadataDictionary.Keys)
+            {
+                var propertyCopy = new ConcurrentDictionary<string, PropertyMetadata>();
+                copy.TryAdd(typeKey, propertyCopy);
+
+                var propertyDictionary = _propertyMetadataDictionary[typeKey];
+
+                foreach (var propertyKey in propertyDictionary.Keys)
+                {
+                    propertyCopy.TryAdd(propertyKey, new PropertyMetadata(propertyDictionary[propertyKey]));
+                }
+            }
+
+            return new MetadataStore(copy);
+        }
+    }
+}

--- a/ExRam.Gremlinq.Core/Models/Metadata/PropertyMetadata.cs
+++ b/ExRam.Gremlinq.Core/Models/Metadata/PropertyMetadata.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExRam.Gremlinq.Core
+{
+    public class PropertyMetadata
+    {
+        public bool IsReadOnly { get; internal set; }
+
+        public bool IsIgnored { get; internal set; }
+
+        public PropertyMetadata()
+        {
+
+        }
+
+        public PropertyMetadata(PropertyMetadata source)
+        {
+            IsReadOnly = source.IsReadOnly;
+            IsIgnored = source.IsIgnored;
+        }
+    }
+}

--- a/ExRam.Gremlinq.Core/Queries/GremlinQuery (explicit interface impl).cs
+++ b/ExRam.Gremlinq.Core/Queries/GremlinQuery (explicit interface impl).cs
@@ -38,7 +38,15 @@ namespace ExRam.Gremlinq.Core
 
         IEdgeGremlinQuery<TEdge, TElement> IVertexGremlinQuery<TElement>.AddE<TEdge>() => AddE(new TEdge());
 
+        IEdgeGremlinQuery<TItem> IGremlinQuerySource.UpdateE<TItem>(TItem edge) => UpdateE(edge);
+
+        IEdgeGremlinQuery<TItem> IGremlinQuerySource.ReplaceE<TItem>(TItem edge) => ReplaceE(edge);
+
         IVertexGremlinQuery<TVertex> IGremlinQuerySource.AddV<TVertex>(TVertex vertex) => AddV(vertex);
+
+        IVertexGremlinQuery<TVertex> IGremlinQuerySource.UpdateV<TVertex>(TVertex vertex) => UpdateV(vertex);
+
+        IVertexGremlinQuery<TVertex> IGremlinQuerySource.ReplaceV<TVertex>(TVertex vertex) => ReplaceV(vertex);
 
         IGremlinQueryAdmin IGremlinQuery.AsAdmin() => this;
 

--- a/ExRam.Gremlinq.Core/Queries/GremlinQuery.cs
+++ b/ExRam.Gremlinq.Core/Queries/GremlinQuery.cs
@@ -117,11 +117,37 @@ namespace ExRam.Gremlinq.Core
                 .AddElementProperties(newEdge, false);
         }
 
+        private GremlinQuery<TEdge, TElement, Unit, Unit, Unit, Unit> UpdateE<TEdge>(TEdge edge)
+        {
+            return this.AddElementPropertiesForUpdate<TEdge, TElement>(edge, false);
+        }
+
+        private GremlinQuery<TEdge, TElement, Unit, Unit, Unit, Unit> ReplaceE<TEdge>(TEdge edge)
+        {
+            var pi = edge.GetType().GetProperties().FirstOrDefault(p => string.Equals(p.Name, "id", StringComparison.OrdinalIgnoreCase));
+
+            if (pi == null)
+            {
+                throw new InvalidOperationException($"Unable to determine Id for {edge}");
+            }
+
+            var id = pi.GetValue(edge);
+
+            return AddStep(new EStep(new[] { id }))
+                .UpdateE(edge);
+        }
+
         private GremlinQuery<TElement, TOutVertex, TInVertex, TPropertyValue, TMeta, TFoldedQuery> AddElementProperties(object element, bool allowExplicitCardinality)
         {
             var ret = this;
 
-            foreach (var (propertyInfo, value) in element.Serialize())
+            var elementType = element.GetType();
+
+            // Only pull back the properties that aren't filtered by configuration
+            var props = element.Serialize()
+                .Where(p => !Model.MetadataStore.TryGetPropertyMetadata(elementType, p.Item1).IsIgnored);
+
+            foreach (var (propertyInfo, value) in props)
             {
                 foreach (var propertyStep in GetPropertySteps(propertyInfo.PropertyType, Model.GetIdentifier(Expression.Property(Expression.Constant(element), propertyInfo)), value, allowExplicitCardinality))
                 {
@@ -159,6 +185,35 @@ namespace ExRam.Gremlinq.Core
             }
         }
 
+        private GremlinQuery<TNewElement, TNewOutVertex, Unit, Unit, Unit, Unit> AddElementPropertiesForUpdate<TNewElement, TNewOutVertex>(object element, bool allowExplicitCardinality)
+        {
+            var elementType = element.GetType();
+
+            // Only pull back the properties that aren't filtered by configuration
+            var props = element.Serialize()
+                .Where(p => {
+                    var m = Model.MetadataStore.TryGetPropertyMetadata(elementType, p.Item1);
+                    return !m.IsReadOnly && !m.IsIgnored;
+                });
+
+            // Drop the properties we found from the existing item
+            var drop = Anonymize().Properties<Unit, Unit, Unit>(props.Select(p => p.Item1.Name))
+                       .Drop();
+
+            var ret = AddStep<TNewElement, TNewOutVertex, Unit, Unit, Unit, Unit>(new SideEffectStep(drop));
+
+            // Re-add the properties
+            foreach (var (propertyInfo, value) in props)
+            {
+                foreach (var propertyStep in GetPropertySteps(propertyInfo.PropertyType, Model.GetIdentifier(Expression.Property(Expression.Constant(element), propertyInfo)), value, allowExplicitCardinality))
+                {
+                    ret = ret.AddStep(propertyStep);
+                }
+            }
+
+            return ret;
+        }
+
         private GremlinQuery<TElement, TOutVertex, TInVertex, TPropertyValue, TMeta, TFoldedQuery> AddStep(Step step) => AddStep<TElement>(step);
 
         private GremlinQuery<TNewElement, TOutVertex, TInVertex, TPropertyValue, TMeta, TFoldedQuery> AddStep<TNewElement>(Step step) => AddStep<TNewElement, TOutVertex, TInVertex, TPropertyValue, TMeta, TFoldedQuery>(step);
@@ -190,6 +245,26 @@ namespace ExRam.Gremlinq.Core
             return this
                 .AddStep<TVertex, Unit, Unit, Unit, Unit, Unit>(new AddVStep(Model, vertex))
                 .AddElementProperties(vertex, true);
+        }
+
+        private GremlinQuery<TVertex, Unit, Unit, Unit, Unit, Unit> UpdateV<TVertex>(TVertex vertex)
+        {
+            return this.AddElementPropertiesForUpdate<TVertex, Unit>(vertex, true);
+        }
+
+        private GremlinQuery<TVertex, Unit, Unit, Unit, Unit, Unit> ReplaceV<TVertex>(TVertex vertex)
+        {
+            var pi = vertex.GetType().GetProperties().FirstOrDefault(p => string.Equals(p.Name, "id", StringComparison.OrdinalIgnoreCase));
+
+            if (pi == null)
+            {
+                throw new InvalidOperationException($"Unable to determine Id for {vertex}");
+            }
+
+            var id = pi.GetValue(vertex);
+
+            return AddStep(new VStep(new[] { id }))
+                .UpdateV(vertex);
         }
 
         private TTargetQuery Aggregate<TStepLabel, TTargetQuery>(Func<GremlinQuery<TElement, TOutVertex, TInVertex, TPropertyValue, TMeta, TFoldedQuery>, TStepLabel, TTargetQuery> continuation)
@@ -653,7 +728,7 @@ namespace ExRam.Gremlinq.Core
                 {
                     var ret = this;
 
-                    foreach(var propertyStep in GetPropertySteps(memberExpression.Type, identifier, value, true))
+                    foreach (var propertyStep in GetPropertySteps(memberExpression.Type, identifier, value, true))
                     {
                         ret = ret.AddStep(propertyStep);
                     }
@@ -707,45 +782,45 @@ namespace ExRam.Gremlinq.Core
                 switch (terminal.Key)
                 {
                     case MemberExpression leftMemberExpression:
-                    {
-                        if (leftMemberExpression.Expression == terminal.Parameter)
                         {
-                            // x => x.Value == P.xy(...)
-                            if (leftMemberExpression.IsPropertyValue())
-                                return AddStep(new HasValueStep(terminal.Predicate));
+                            if (leftMemberExpression.Expression == terminal.Parameter)
+                            {
+                                // x => x.Value == P.xy(...)
+                                if (leftMemberExpression.IsPropertyValue())
+                                    return AddStep(new HasValueStep(terminal.Predicate));
 
-                            if (leftMemberExpression.IsPropertyKey())
-                                return Where(__ => __.Key().Where(terminal.Predicate));
+                                if (leftMemberExpression.IsPropertyKey())
+                                    return Where(__ => __.Key().Where(terminal.Predicate));
 
-                            if (leftMemberExpression.IsVertexPropertyLabel())
-                                return Where(__ => __.Label().Where(terminal.Predicate));
+                                if (leftMemberExpression.IsVertexPropertyLabel())
+                                    return Where(__ => __.Label().Where(terminal.Predicate));
+                            }
+                            else if (leftMemberExpression.Expression is MemberExpression leftLeftMemberExpression)
+                            {
+                                // x => x.Name.Value == P.xy(...)
+                                if (leftMemberExpression.IsPropertyValue())
+                                    leftMemberExpression = leftLeftMemberExpression;    //TODO: What else ?
+                            }
+                            else
+                                break;
+
+                            // x => x.Name == P.xy(...)
+                            return Where(leftMemberExpression, terminal.Predicate);
                         }
-                        else if (leftMemberExpression.Expression is MemberExpression leftLeftMemberExpression) 
-                        {
-                            // x => x.Name.Value == P.xy(...)
-                            if (leftMemberExpression.IsPropertyValue())
-                                leftMemberExpression = leftLeftMemberExpression;    //TODO: What else ?
-                        }
-                        else
-                            break;
-
-                        // x => x.Name == P.xy(...)
-                        return Where(leftMemberExpression, terminal.Predicate);
-                    }
                     case ParameterExpression leftParameterExpression when terminal.Parameter == leftParameterExpression:
-                    {
-                        // x => x == P.xy(...)
-                        return Where(terminal.Predicate);
-                    }
-                    case MethodCallExpression methodCallExpression:
-                    {
-                        if (typeof(IDictionary<string, object>).IsAssignableFrom(methodCallExpression.Object.Type) && methodCallExpression.Method.Name == "get_Item")
                         {
-                            return AddStep(new HasStep(methodCallExpression.Arguments[0].GetValue(), terminal.Predicate));
+                            // x => x == P.xy(...)
+                            return Where(terminal.Predicate);
                         }
+                    case MethodCallExpression methodCallExpression:
+                        {
+                            if (typeof(IDictionary<string, object>).IsAssignableFrom(methodCallExpression.Object.Type) && methodCallExpression.Method.Name == "get_Item")
+                            {
+                                return AddStep(new HasStep(methodCallExpression.Arguments[0].GetValue(), terminal.Predicate));
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
                 }
             }
 

--- a/ExRam.Gremlinq.Core/Queries/QuerySource/GremlinQuerySource.cs
+++ b/ExRam.Gremlinq.Core/Queries/QuerySource/GremlinQuerySource.cs
@@ -38,6 +38,30 @@ namespace ExRam.Gremlinq.Core
                     .AddE(edge);
             }
 
+            IEdgeGremlinQuery<TItem> IGremlinQuerySource.UpdateE<TItem>(TItem edge)
+            {
+                return Create()
+                    .UpdateE(edge);
+            }
+
+            IEdgeGremlinQuery<TItem> IGremlinQuerySource.ReplaceE<TItem>(TItem edge)
+            {
+                return Create()
+                    .ReplaceE(edge);
+            }
+
+            IVertexGremlinQuery<TVertex> IGremlinQuerySource.UpdateV<TVertex>(TVertex vertex)
+            {
+                return Create()
+                    .UpdateV(vertex);
+            }
+
+            IVertexGremlinQuery<TVertex> IGremlinQuerySource.ReplaceV<TVertex>(TVertex vertex)
+            {
+                return Create()
+                    .ReplaceV(vertex);
+            }
+
             IVertexGremlinQuery<IVertex> IGremlinQuerySource.V(params object[] ids)
             {
                 return Create()
@@ -138,10 +162,10 @@ namespace ExRam.Gremlinq.Core
         }
 
         // ReSharper disable once InconsistentNaming
-        #pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable IDE1006 // Naming Styles
         public static readonly IConfigurableGremlinQuerySource g = Create();
-        #pragma warning restore IDE1006 // Naming Styles
-    
+#pragma warning restore IDE1006 // Naming Styles
+
         public static IConfigurableGremlinQuerySource Create(string name = "g")
         {
             return new ConfigurableGremlinQuerySourceImpl(name, GraphModel.Dynamic(NullLogger.Instance).Relax(), false, GremlinQueryExecutor.Invalid, ImmutableList<IGremlinQueryStrategy>.Empty, ImmutableList<string>.Empty, NullLogger.Instance);

--- a/ExRam.Gremlinq.Core/Queries/QuerySource/IGremlinQuerySource.cs
+++ b/ExRam.Gremlinq.Core/Queries/QuerySource/IGremlinQuerySource.cs
@@ -1,4 +1,6 @@
-﻿using ExRam.Gremlinq.Core.GraphElements;
+﻿using System;
+using System.Collections.Immutable;
+using ExRam.Gremlinq.Core.GraphElements;
 
 namespace ExRam.Gremlinq.Core
 {
@@ -6,10 +8,14 @@ namespace ExRam.Gremlinq.Core
     {
         IVertexGremlinQuery<TVertex> AddV<TVertex>(TVertex vertex);
         IEdgeGremlinQuery<TEdge> AddE<TEdge>(TEdge edge);
+        IEdgeGremlinQuery<TItem> UpdateE<TItem>(TItem edge);
+        IVertexGremlinQuery<TItem> UpdateV<TItem>(TItem vertex);
         IVertexGremlinQuery<IVertex> V(params object[] ids);
         IVertexGremlinQuery<TVertex> V<TVertex>(params object[] ids);
         IEdgeGremlinQuery<IEdge> E(params object[] ids);
         IEdgeGremlinQuery<TEdge> E<TEdge>(params object[] ids);
         IGremlinQuery<TElement> Inject<TElement>(params TElement[] elements);
+        IVertexGremlinQuery<TVertex> ReplaceV<TVertex>(TVertex vertex);
+        IEdgeGremlinQuery<TItem> ReplaceE<TItem>(TItem edge);
     }
 }

--- a/ExRam.Gremlinq.Providers.CosmosDb.Tests/GroovySerializationTest.cs
+++ b/ExRam.Gremlinq.Providers.CosmosDb.Tests/GroovySerializationTest.cs
@@ -1,48 +1,3126 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.Linq;
-using ExRam.Gremlinq.Core.Tests;
+using ExRam.Gremlinq.Core.GraphElements;
+using ExRam.Gremlinq.Core.Serialization;
 using ExRam.Gremlinq.Tests.Entities;
 using FluentAssertions;
 using Xunit;
 using static ExRam.Gremlinq.Core.GremlinQuerySource;
 
-namespace ExRam.Gremlinq.Providers.CosmosDb.Tests
+namespace ExRam.Gremlinq.Core.Tests
 {
-    public class GroovySerializationTest : GroovySerializationTest<CosmosDbGroovyGremlinQueryElementVisitor>
+    public abstract class GroovySerializationTest<TVisitor> where TVisitor : IGremlinQueryElementVisitor<SerializedGremlinQuery>, new()
     {
-        [Fact]
-        public void Limit_overflow()
+        protected GroovySerializationTest()
         {
-            g
-                .V()
-                .Limit((long)int.MaxValue + 1)
-                .Invoking(x => new CosmosDbGroovyGremlinQueryElementVisitor().Visit(x))
-                .Should()
-                .Throw<ArgumentOutOfRangeException>();
+            var vertexType = typeof(Vertex);
         }
 
         [Fact]
-        public void Where_property_array_intersects_empty_array()
+        public void AddE_from_StepLabel()
+        {
+            g
+                .AddV(new Country { CountryCallingCode = "+49" })
+                .As((_, c) => _
+                    .AddV(new Language { IetfLanguageTag = "en" })
+                    .AddE<Speaks>()
+                    .From(c))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c).as(_d).addV(_e).property(single, _f, _g).addE(_h).from(_d)")
+                .WithParameters("Country", "CountryCallingCode", "+49", "l1", "Language", "IetfLanguageTag", "en", "Speaks");
+        }
+
+        [Fact]
+        public void AddE_from_traversal()
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            g
+                .AddV(new Person
+                {
+                    Name = "Bob",
+                    RegistrationDate = now
+                })
+                .AddE(new LivesIn())
+                .From(__ => __
+                    .V<Country>()
+                    .Where(t => t.CountryCallingCode == "+49"))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c).property(single, _d, _e).property(single, _f, _g).property(single, _h, _i).addE(_j).from(__.V().hasLabel(_k).has(_l, _m))")
+                .WithParameters("Person", "Age", 0, "Name", "Bob", "Gender", 0, "RegistrationDate", now, "LivesIn", "Country", "CountryCallingCode", "+49");
+        }
+
+        [Fact]
+        public void AddE_InV()
+        {
+            g
+                .AddV<Person>()
+                .AddE<LivesIn>()
+                .To(__ => __
+                    .V<Country>("id"))
+                .InV()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c).property(single, _d, _e).property(single, _f, _g).addE(_h).to(__.V(_i).hasLabel(_j)).inV()");
+        }
+
+        [Fact]
+        public void AddE_property()
+        {
+            g
+                .AddV<Person>()
+                .AddE(new LivesIn
+                {
+                    Since = DateTimeOffset.Now
+                })
+                .To(__ => __
+                    .V<Country>("id"))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c).property(single, _d, _e).property(single, _f, _g).addE(_h).property(_i, _j).to(__.V(_k).hasLabel(_l))");
+        }
+
+        [Fact]
+        public void AddE_OutV()
+        {
+            g
+                .AddV<Person>()
+                .AddE<LivesIn>()
+                .To(__ => __
+                    .V<Country>("id"))
+                .OutV()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c).property(single, _d, _e).property(single, _f, _g).addE(_h).to(__.V(_i).hasLabel(_j)).outV()");
+        }
+
+        [Fact]
+        public void AddE_to_StepLabel()
+        {
+            g
+                .AddV(new Language { IetfLanguageTag = "en" })
+                .As((_, l) => _
+                    .AddV(new Country { CountryCallingCode = "+49" })
+                    .AddE<Speaks>()
+                    .To(l))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c).as(_d).addV(_e).property(single, _f, _g).addE(_h).to(_d)")
+                .WithParameters("Language", "IetfLanguageTag", "en", "l1", "Country", "CountryCallingCode", "+49", "Speaks");
+        }
+
+        [Fact]
+        public void AddE_to_traversal()
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            g
+                .AddV(new Person
+                {
+                    Name = "Bob",
+                    RegistrationDate = now
+                })
+                .AddE(new LivesIn())
+                .To(__ => __
+                    .V<Country>()
+                    .Where(t => t.CountryCallingCode == "+49"))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c).property(single, _d, _e).property(single, _f, _g).property(single, _h, _i).addE(_j).to(__.V().hasLabel(_k).has(_l, _m))")
+                .WithParameters("Person", "Age", 0, "Name", "Bob", "Gender", 0, "RegistrationDate", now, "LivesIn", "Country", "CountryCallingCode", "+49");
+        }
+
+        [Fact]
+        public void AddE_With_Ignored()
+        {
+            var now = DateTime.UtcNow;
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<WorksFor>()
+                    .Ignored(p => p.From)
+                    .Ignored(p => p.Role);
+            });
+
+            local
+                .AddE(new WorksFor { From = now, To = now, Role = "Admin" })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addE(_a).property(_b, _c)")
+                .WithParameters("WorksFor", nameof(WorksFor.To), now);
+        }
+
+        [Fact]
+        public void AddV()
+        {
+            g
+                .AddV(new Language { Id = 1, IetfLanguageTag = "en" })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(id, _b).property(single, _c, _d)")
+                .WithParameters("Language", 1, "IetfLanguageTag", "en");
+        }
+
+        [Fact]
+        public void AddV_list_cardinality_id()
+        {
+            g
+                .WithModel(GraphModel
+                    .FromExecutingAssembly<VertexWithListAsId, Edge>())
+                .AddV(new VertexWithListAsId { Id = new[] { "123", "456" } })
+                .Invoking(x => new GroovyGremlinQueryElementVisitor().Visit(x))
+                .Should()
+                .Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void AddV_with_enum_property()
+        {
+            g
+                .AddV(new Person { Id = 1, Gender = Gender.Female })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(id, _b).property(single, _c, _d).property(single, _e, _f).property(single, _g, _h)")
+                .WithParameters("Person", 1, "Age", 0, "Gender", 1, "RegistrationDate", DateTimeOffset.MinValue);
+        }
+
+        [Fact]
+        public void AddV_with_Meta_with_properties()
+        {
+            g
+                .AddV(new Country
+                {
+                    Id = 1,
+                    Name = new VertexProperty<string>("GER")
+                    {
+                        Properties =
+                        {
+                            { "de", "Deutschland" },
+                            { "en", "Germany" }
+                        }
+                    }
+                })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(id, _b).property(single, _c, _d, _e, _f, _g, _h)")
+                .WithParameters("Country", 1, "Name", "GER", "de", "Deutschland", "en", "Germany");
+        }
+
+        [Fact]
+        public void AddV_with_Meta_without_properties()
+        {
+            g
+                .AddV(new Country { Id = 1, Name = "GER" })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(id, _b).property(single, _c, _d)")
+                .WithParameters("Country", 1, "Name", "GER");
+        }
+
+        [Fact]
+        public void AddV_with_MetaModel()
+        {
+            g
+                .AddV(new Company
+                {
+                    Id = 1,
+                    Name = new[]
+                    {
+                        new VertexProperty<string, PropertyValidity>("Bob")
+                        {
+                            Properties = new PropertyValidity
+                            {
+                                ValidFrom = DateTimeOffset.Parse("01.01.2019 08:00")
+                            }
+                        }
+                    }
+                })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(id, _b).property(single, _c, _d).property(list, _e, _f, _g, _h)")
+                .WithParameters("Company", 1, "FoundingDate", DateTime.MinValue, "Name", "Bob", "ValidFrom", DateTimeOffset.Parse("01.01.2019 08:00"));
+        }
+
+        [Fact]
+        public void AddV_with_multi_property()
+        {
+            g
+                .AddV(new Company { Id = 1, PhoneNumbers = new[] { "+4912345", "+4923456" } })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(id, _b).property(single, _c, _d).property(list, _e, _f).property(list, _e, _g)")
+                .WithParameters("Company", 1, "FoundingDate", DateTime.MinValue, "PhoneNumbers", "+4912345", "+4923456");
+        }
+
+        [Fact]
+        public void AddV_with_nulls()
+        {
+            g
+                .AddV(new Language { Id = 1 })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(id, _b)")
+                .WithParameters("Language", 1);
+        }
+
+        [Fact]
+        public void AddV_without_id()
+        {
+            g
+                .AddV(new Language { IetfLanguageTag = "en" })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c)")
+                .WithParameters("Language", "IetfLanguageTag", "en");
+        }
+
+        [Fact]
+        public void AddV_without_model()
+        {
+            g
+                .WithModel(GraphModel.Empty)
+                .AddV(new Language { Id = 1, IetfLanguageTag = "en" })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c).property(single, _d, _e)")
+                .WithParameters("Language", "IetfLanguageTag", "en", "Id", 1);
+        }
+
+        [Fact]
+        public void AddV_With_Ignored()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var person = new Person { Age = 21, Gender = Gender.Male, Name = "Marko", RegistrationDate = now };
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<Person>()
+                    .Ignored(p => p.Age)
+                    .Ignored(p => p.Gender);
+            });
+
+            local
+                .AddV(person)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.addV(_a).property(single, _b, _c).property(single, _d, _e)")
+                .WithParameters("Person", "Name", "Marko", "RegistrationDate", now);
+        }
+
+        [Fact]
+        public void And()
+        {
+            g
+                .V<Person>()
+                .And(
+                    __ => __
+                        .InE<WorksFor>(),
+                    __ => __
+                        .OutE<LivesIn>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).and(__.inE(_b), __.outE(_c))")
+                .WithParameters("Person", "WorksFor", "LivesIn");
+        }
+
+        [Fact]
+        public void And_nested()
+        {
+            g
+                .V<Person>()
+                .And(
+                    __ => __
+                        .OutE<LivesIn>(),
+                    __ => __
+                        .And(
+                            ___ => ___
+                                .InE<WorksFor>(),
+                            ___ => ___
+                                .OutE<WorksFor>()))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).and(__.outE(_b), __.inE(_c), __.outE(_c))")
+                .WithParameters("Person", "LivesIn", "WorksFor");
+        }
+
+        [Fact]
+        public void Anonymous()
+        {
+            GremlinQuery.Anonymous()
+                .Should()
+                .SerializeToGroovy<TVisitor>("__.identity()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void As_explicit_label1()
+        {
+            g
+                .V<Person>()
+                .As(new StepLabel<Person>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).as(_b)")
+                .WithParameters("Person", "l1");
+        }
+
+        [Fact]
+        public void As_explicit_label2()
+        {
+            g
+                .V<Person>()
+                .As(new StepLabel<Person>(), new StepLabel<Person>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).as(_b, _c)")
+                .WithParameters("Person", "l1", "l2");
+        }
+
+        [Fact]
+        public void As_inlined_nested_Select()
+        {
+            g
+                .V<Person>()
+                .As((_, stepLabel1) => _
+                    .As((__, stepLabel2) => __
+                        .Select(stepLabel1, stepLabel2)))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).as(_b).as(_c).select(_b, _c)")
+                .WithParameters("Person", "<1>Item1", "<2>Item2");
+        }
+
+        [Fact]
+        public void Choose_Predicate1()
+        {
+            g
+                .V()
+                .Id()
+                .Choose(
+                    x => x == (object)42,
+                    _ => _.Constant(true),
+                    _ => _.Constant(false))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().id().choose(eq(_a), __.constant(_b), __.constant(_c))")
+                .WithParameters(42, true, false);
+        }
+
+        [Fact]
+        public void Choose_Predicate2()
+        {
+            g
+                .V()
+                .Id()
+                .Choose(
+                    x => x == (object)42,
+                    _ => _.Constant(true))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().id().choose(eq(_a), __.constant(_b))")
+                .WithParameters(42, true);
+        }
+
+        [Fact]
+        public void Choose_Predicate3()
+        {
+            g
+                .V()
+                .Id()
+                .Cast<int>()
+                .Choose(
+                    x => x < 42,
+                    _ => _.Constant(true),
+                    _ => _.Constant(false))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().id().choose(lt(_a), __.constant(_b), __.constant(_c))")
+                .WithParameters(42, true, false);
+        }
+
+        [Fact]
+        public void Choose_Predicate4()
+        {
+            g
+                .V()
+                .Id()
+                .Cast<int>()
+                .Choose(
+                    x => 42 > x,
+                    _ => _.Constant(true),
+                    _ => _.Constant(false))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().id().choose(lt(_a), __.constant(_b), __.constant(_c))")
+                .WithParameters(42, true, false);
+        }
+
+        [Fact]
+        public void Choose_Predicate5()
+        {
+            g
+                .V()
+                .Id()
+                .Cast<int>()
+                .Choose(
+                    x => 0 < x && x < 42,
+                    _ => _.Constant(true),
+                    _ => _.Constant(false))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().id().choose(gt(_a).and(lt(_b)), __.constant(_c), __.constant(_d))")
+                .WithParameters(0, 42, true, false);
+        }
+
+        [Fact]
+        public void Choose_Predicate6()
+        {
+            g
+                .V()
+                .Id()
+                .Cast<int>()
+                .Choose(
+                    x => 0 < x && x < 42 || x != 37,
+                    _ => _.Constant(true),
+                    _ => _.Constant(false))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().id().choose(gt(_a).and(lt(_b)).or(neq(_c)), __.constant(_d), __.constant(_e))")
+                .WithParameters(0, 42, 37, true, false);
+        }
+
+        [Fact]
+        public void Choose_Predicate7()
+        {
+            g
+                .V()
+                .Id()
+                .Cast<int>()
+                .Choose(
+                    x => 0 < x || x < 42 && x != 37,
+                    _ => _.Constant(true),
+                    _ => _.Constant(false))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().id().choose(gt(_a).or(lt(_b).and(neq(_c))), __.constant(_d), __.constant(_e))")
+                .WithParameters(0, 42, 37, true, false);
+        }
+
+        [Fact]
+        public void Choose_Traversal1()
+        {
+            g
+                .V()
+                .Choose(
+                    _ => _.Values(),
+                    _ => _.Out(),
+                    _ => _.In())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().choose(__.values(), __.out(), __.in())")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Choose_Traversal2()
+        {
+            g
+                .V()
+                .Choose(
+                    _ => _.Values(),
+                    _ => _.Out())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().choose(__.values(), __.out())")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Coalesce()
+        {
+            g
+                .V()
+                .Coalesce(
+                    _ => _
+                        .Identity())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().coalesce(__.identity())")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Constant()
+        {
+            g
+                .V()
+                .Constant(42)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().constant(_a)")
+                .WithParameters(42);
+        }
+
+        [Fact]
+        public void Count()
+        {
+            g
+                .V()
+                .Count()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().count()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void CountGlobal()
+        {
+            g
+                .V()
+                .Count()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().count()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void CountLocal()
+        {
+            g
+                .V()
+                .CountLocal()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().count(local)")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Drop()
+        {
+            g
+                .V<Person>()
+                .Drop()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).drop()")
+                .WithParameters("Person");
+        }
+
+        [Fact]
+        public void E_of_all_types1()
+        {
+            g
+                .E<object>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void E_of_all_types2()
+        {
+            g
+                .E<IEdge>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void E_of_concrete_type()
+        {
+            g
+                .E<WorksFor>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E().hasLabel(_a)")
+                .WithParameters("WorksFor");
+        }
+
+        [Fact]
+        public void E_of_type_outside_model()
+        {
+            g
+                .WithModel(GraphModel.Dynamic())
+                .Invoking(_ => _
+                    .E<string>())
+                .Should()
+                .Throw<GraphModelException>();
+        }
+
+        [Fact]
+        public void E_Properties()
+        {
+            g
+                .E()
+                .Properties()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E().properties()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void E_Properties_member()
+        {
+            g
+                .E<LivesIn>()
+                .Properties(x => x.Since)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E().hasLabel(_a).properties(_b)")
+                .WithParameters("LivesIn", "Since");
+        }
+
+        [Fact]
+        public void FilterWithLambda()
+        {
+            g
+                .V<Person>()
+                .Where("it.property('str').value().length() == 2")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).filter({it.property('str').value().length() == 2})")
+                .WithParameters("Person");
+        }
+
+        [Fact]
+        public void FlatMap()
+        {
+            g
+                .V<Person>()
+                .FlatMap(__ => __.Out<WorksFor>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).flatMap(__.out(_b))")
+                .WithParameters("Person", "WorksFor");
+        }
+
+        [Fact]
+        public void Fold()
+        {
+            g
+                .V()
+                .Fold()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().fold()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Fold_Fold_Unfold_Unfold()
+        {
+            g
+                .V()
+                .Fold()
+                .Fold()
+                .Unfold()
+                .Unfold()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().fold().fold().unfold().unfold()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Fold_SideEffect()
+        {
+            g
+                .V()
+                .Fold()
+                .SideEffect(x => x.Identity())
+                .Unfold()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().fold().sideEffect(__.identity()).unfold()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Fold_Unfold()
+        {
+            g
+                .V()
+                .Fold()
+                .Unfold()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().fold().unfold()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void In()
+        {
+            g
+                .V<Person>()
+                .In<WorksFor>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).in(_b)")
+                .WithParameters("Person", "WorksFor");
+        }
+
+        [Fact]
+        public void In_of_all_types()
+        {
+            g
+                .V()
+                .In<object>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().in()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void InE_of_all_types()
+        {
+            g
+                .V()
+                .InE<object>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().inE()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Inject()
+        {
+            g
+                .Inject(36, 37, 38)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.inject(_a, _b, _c)")
+                .WithParameters(36, 37, 38);
+        }
+
+        [Fact]
+        public void Label()
+        {
+            g
+                .V()
+                .Label()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().label()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Limit_underflow()
+        {
+            g
+                .V()
+                .Invoking(_ => _.Limit(-1))
+                .Should()
+                .Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void LimitGlobal()
+        {
+            g
+                .V()
+                .Limit(1)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().limit(_a)")
+                .WithParameters(1);
+        }
+
+        [Fact]
+        public void LimitLocal()
+        {
+            g
+                .V()
+                .LimitLocal(1)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().limit(local, _a)")
+                .WithParameters(1);
+        }
+
+        [Fact]
+        public void Map()
+        {
+            g
+                .V<Person>()
+                .Map(__ => __.Out<WorksFor>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).map(__.out(_b))")
+                .WithParameters("Person", "WorksFor");
+        }
+
+        [Fact]
+        public void Map_Select_operation()
+        {
+            g
+                .V<Person>()
+                .As((_, stepLabel1) => _
+                    .As((__, stepLabel2) => __
+                        .Map(___ => ___
+                            .Select(stepLabel1, stepLabel2))))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).as(_b).as(_c).map(__.select(_b, _c))")
+                .WithParameters("Person", "<1>Item1", "<2>Item2");
+        }
+
+        [Fact]
+        public void Nested_contradicting_Select_operations_throw()
+        {
+            g
+                .V<Person>()
+                .Invoking(x => x
+                    .As((_, stepLabel1) => _
+                        .As((__, stepLabel2) => __
+                            .Select(stepLabel1, stepLabel2)
+                            .As((___, tuple) => ___
+                                .Select(tuple, stepLabel1)))))
+                .Should()
+                .Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void Nested_Select_operations()
+        {
+            g
+                .V<Person>()
+                .As((_, stepLabel1) => _
+                    .As((__, stepLabel2) => __
+                        .Select(stepLabel1, stepLabel2)
+                        .As((___, tuple) => ___
+                            .Select(stepLabel1, tuple))))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).as(_b).as(_c).select(_b, _c).as(_d).select(_b, _d)")
+                .WithParameters("Person", "<1>Item1", "<2>Item2", "<3>Item2");
+        }
+
+        [Fact]
+        public void Not1()
+        {
+            g
+                .V()
+                .Not(__ => __.Out<WorksFor>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().not(__.out(_a))")
+                .WithParameters("WorksFor");
+        }
+
+        [Fact]
+        public void Not2()
+        {
+            g
+                .V()
+                .Not(__ => __.OfType<Language>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().not(__.hasLabel(_a))")
+                .WithParameters("Language");
+        }
+
+        [Fact]
+        public void Not3()
+        {
+            g
+                .V()
+                .Not(__ => __.OfType<Authority>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().not(__.hasLabel(_a, _b))")
+                .WithParameters("Company", "Person");
+        }
+
+        [Fact]
+        public void OfType_abstract()
+        {
+            g
+                .V()
+                .OfType<Authority>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a, _b)")
+                .WithParameters("Company", "Person");
+        }
+
+        [Fact]
+        public void OfType_redundant1()
+        {
+            g
+                .V()
+                .OfType<Company>()
+                .OfType<Authority>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a)")
+                .WithParameters("Company");
+        }
+
+        [Fact]
+        public void OfType_redundant2()
+        {
+            g
+                .V()
+                .OfType<Company>()
+                .OfType<object>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a)")
+                .WithParameters("Company");
+        }
+
+        [Fact]
+        public void Optional()
+        {
+            g
+                .V()
+                .Optional(
+                    __ => __.Out<WorksFor>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().optional(__.out(_a))")
+                .WithParameters("WorksFor");
+        }
+
+        [Fact]
+        public void Or()
+        {
+            g
+                .V<Person>()
+                .Or(
+                    __ => __
+                        .InE<WorksFor>(),
+                    __ => __
+                        .OutE<LivesIn>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).or(__.inE(_b), __.outE(_c))")
+                .WithParameters("Person", "WorksFor", "LivesIn");
+        }
+
+        [Fact]
+        public void Or_nested()
+        {
+            g
+                .V<Person>()
+                .Or(
+                    __ => __
+                        .OutE<LivesIn>(),
+                    __ => __
+                        .Or(
+                            ___ => ___
+                                .InE<WorksFor>(),
+                            ___ => ___
+                                .OutE<WorksFor>()))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).or(__.outE(_b), __.inE(_c), __.outE(_c))")
+                .WithParameters("Person", "LivesIn", "WorksFor");
+        }
+
+        [Fact]
+        public void Order_Fold_Unfold()
+        {
+            g
+                .V()
+                .OrderBy(x => x.Id)
+                .Fold()
+                .Unfold()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().order().by(id, incr).fold().unfold()");
+        }
+
+        [Fact]
+        public void OrderBy_lambda()
+        {
+            g
+                .V<Person>()
+                .OrderBy("it.property('str').value().length()")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by({it.property('str').value().length()})")
+                .WithParameters("Person");
+        }
+
+        [Fact]
+        public void OrderBy_member()
+        {
+            g
+                .V<Person>()
+                .OrderBy(x => x.Name)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by(_b, incr)")
+                .WithParameters("Person", "Name");
+        }
+
+        [Fact]
+        public void OrderBy_ThenBy_lambda()
+        {
+            g
+                .V<Person>()
+                .OrderBy("it.property('str1').value().length()")
+                .ThenBy("it.property('str2').value().length()")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by({it.property('str1').value().length()}).by({it.property('str2').value().length()})")
+                .WithParameters("Person");
+        }
+
+        [Fact]
+        public void OrderBy_member_ThenBy_member()
+        {
+            g
+                .V<Person>()
+                .OrderBy(x => x.Name)
+                .ThenBy(x => x.Age)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by(_b, incr).by(_c, incr)")
+                .WithParameters("Person", "Name", "Age");
+        }
+
+        [Fact]
+        public void OrderBy_traversal_ThenBy()
+        {
+            g
+                .V<Person>()
+                .OrderBy(__ => __.Values(x => x.Name))
+                .ThenBy(__ => __.Gender)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by(__.values(_b), incr).by(_c, incr)")
+                .WithParameters("Person", "Name", "Gender");
+        }
+
+        [Fact]
+        public void OrderBy_traversal_ThenBy_traversal()
+        {
+            g
+                .V<Person>()
+                .OrderBy(__ => __.Values(x => x.Name))
+                .ThenBy(__ => __.Values(x => x.Gender))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by(__.values(_b), incr).by(__.values(_c), incr)")
+                .WithParameters("Person", "Name", "Gender");
+        }
+
+        [Fact]
+        public void OrderBy_ThenByDescending_member()
+        {
+            g
+                .V<Person>()
+                .OrderBy(x => x.Name)
+                .ThenByDescending(x => x.Age)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by(_b, incr).by(_c, decr)")
+                .WithParameters("Person", "Name", "Age");
+        }
+
+        [Fact]
+        public void OrderBy_ThenByDescending_traversal()
+        {
+            g
+                .V<Person>()
+                .OrderBy(__ => __.Values(x => x.Name))
+                .ThenByDescending(__ => __.Gender)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by(__.values(_b), incr).by(_c, decr)")
+                .WithParameters("Person", "Name", "Gender");
+        }
+
+        [Fact]
+        public void OrderBy_traversal()
+        {
+            g
+                .V<Person>()
+                .OrderBy(__ => __.Values(x => x.Name))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by(__.values(_b), incr)")
+                .WithParameters("Person", "Name");
+        }
+
+        [Fact]
+        public void OrderByDescending_member()
+        {
+            g
+                .V<Person>()
+                .OrderByDescending(x => x.Name)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by(_b, decr)")
+                .WithParameters("Person", "Name");
+        }
+
+        [Fact]
+        public void OrderByDescending_traversal()
+        {
+            g
+                .V<Person>()
+                .OrderByDescending(__ => __.Values(x => x.Name))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).order().by(__.values(_b), decr)")
+                .WithParameters("Person", "Name");
+        }
+
+        [Fact]
+        public void Out()
+        {
+            g
+                .V<Person>()
+                .Out<WorksFor>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).out(_b)")
+                .WithParameters("Person", "WorksFor");
+        }
+
+        [Fact]
+        public void Out_does_not_include_abstract_edge()
+        {
+            g
+                .V<Person>()
+                .Out<Edge>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).out(_b, _c, _d)")
+                .WithParameters("Person", "LivesIn", "Speaks", "WorksFor");
+        }
+
+        [Fact]
+        public void Out_of_all_types()
+        {
+            g
+                .V()
+                .Out<object>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().out()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Out_of_type_outside_model1()
+        {
+            g
+                .WithModel(GraphModel.Dynamic())
+                .V()
+                .Invoking(_ => _.Out<string>())
+                .Should()
+                .Throw<GraphModelException>();
+        }
+
+        [Fact]
+        public void Out_of_type_outside_model2()
+        {
+            g
+                .WithModel(GraphModel.Dynamic())
+                .V()
+                .Invoking(_ => _.Out<IVertex>())
+                .Should()
+                .Throw<GraphModelException>();
+        }
+
+        [Fact]
+        public void OutE_of_all_types()
+        {
+            g
+                .V()
+                .OutE<object>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().outE()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Project2()
+        {
+            g
+                .V()
+                .Project(
+                    __ => __.In(),
+                    __ => __.Out())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().project(_a, _b).by(__.in()).by(__.out())")
+                .WithParameters("Item1", "Item2");
+        }
+
+        [Fact]
+        public void Project3()
+        {
+            g
+                .V()
+                .Project(
+                    __ => __.In(),
+                    __ => __.Out(),
+                    __ => __.Count())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().project(_a, _b, _c).by(__.in()).by(__.out()).by(__.count())")
+                .WithParameters("Item1", "Item2", "Item3");
+        }
+
+        [Fact]
+        public void Project4()
+        {
+            g
+                .V()
+                .Project(
+                    __ => __.In(),
+                    __ => __.Out(),
+                    __ => __.Count(),
+                    __ => __.Properties())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().project(_a, _b, _c, _d).by(__.in()).by(__.out()).by(__.count()).by(__.properties())")
+                .WithParameters("Item1", "Item2", "Item3", "Item4");
+        }
+
+        [Fact]
+        public void Properties_Meta()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name)
+                .Meta<PropertyValidity>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b)")
+                .WithParameters("Country", "Name");
+        }
+
+        [Fact]
+        public void Properties_Meta_ValueMap()
+        {
+            g
+                .V()
+                .Properties()
+                .Meta<PropertyValidity>()
+                .ValueMap()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().valueMap()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Properties_Meta_Values()
+        {
+            g
+                .V()
+                .Properties()
+                .Meta<PropertyValidity>()
+                .Values()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().values()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Properties_Meta_Values_Projected()
+        {
+            g
+                .V()
+                .Properties()
+                .Meta<PropertyValidity>()
+                .Values(x => x.ValidFrom)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().values(_a)")
+                .WithParameters("ValidFrom");
+        }
+
+        [Fact]
+        public void Properties_Meta_Where1()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name)
+                .Meta<PropertyValidity>()
+                .Where(x => x.Properties.ValidFrom >= DateTimeOffset.Parse("01.01.2019 08:00"))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).has(_c, gte(_d))")
+                .WithParameters("Country", "Name", "ValidFrom", DateTimeOffset.Parse("01.01.2019 08:00"));
+        }
+
+        [Fact]
+        public void Properties_of_member()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b)")
+                .WithParameters("Country", "Name");
+        }
+
+        [Fact]
+        public void Properties_of_three_members()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name, x => x.CountryCallingCode, x => x.Languages)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b, _c, _d)")
+                .WithParameters("Country", "Name", "CountryCallingCode", "Languages");
+        }
+
+        [Fact]
+        public void Properties_of_two_members1()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name, x => x.CountryCallingCode)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b, _c)")
+                .WithParameters("Country", "Name", "CountryCallingCode");
+        }
+
+        [Fact]
+        public void Properties_of_two_members2()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name, x => x.Languages)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b, _c)")
+                .WithParameters("Country", "Name", "Languages");
+        }
+
+        [Fact]
+        public void Properties_Properties1()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name)
+                .Properties()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).properties()")
+                .WithParameters("Country", "Name");
+        }
+
+        [Fact]
+        public void Properties_Properties_key()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name)
+                .Properties()
+                .Key()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).properties().key()")
+                .WithParameters("Country", "Name");
+        }
+
+        [Fact]
+        public void Properties_Properties_as_select()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name)
+                .Properties()
+                .As((__, s) => __
+                    .Select(s))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).properties().as(_c).select(_c)")
+                .WithParameters("Country", "Name", "l1");
+        }
+
+        [Fact]
+        public void Properties_Properties2()
         {
             g
                 .V<Company>()
-                .Where(t => t.PhoneNumbers.Intersect(new string[0]).Any())
+                .Properties(x => x.Name)
+                .Properties()
                 .Should()
-                .SerializeToGroovy<CosmosDbGroovyGremlinQueryElementVisitor>("g.V().hasLabel(_a).not(__.identity())")
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).properties()")
+                .WithParameters("Company", "Name");
+        }
+
+        [Fact]
+        public void Properties_Properties_Value()
+        {
+            g
+                .V<Company>()
+                .Properties(x => x.Name)
+                .Properties()
+                .Value()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).properties().value()")
+                .WithParameters("Company", "Name");
+        }
+
+        [Fact]
+        public void Properties_Where_label()
+        {
+            g
+                .V<Company>()
+                .Properties(x => x.Name)
+                .Where(x => x.Label == "someKey")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).where(__.label().is(_c))")
+                .WithParameters("Company", "Name", "someKey");
+        }
+
+        [Fact]
+        public void Properties_Properties_Where_key()
+        {
+            g
+                .V<Company>()
+                .Properties(x => x.Name)
+                .Properties()
+                .Where(x => x.Key == "someKey")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).properties().where(__.key().is(_c))")
+                .WithParameters("Company", "Name", "someKey");
+        }
+
+        [Fact]
+        public void Properties_Properties_Where_key_equals_stepLabel()
+        {
+            var stepLabel = new StepLabel<string>();
+
+            g
+                .V<Company>()
+                .Properties(x => x.Name)
+                .Properties()
+                .Where(x => x.Key == stepLabel)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).properties().where(__.key().where(eq(_c)))")
+                .WithParameters("Company", "Name", "l1");
+        }
+
+        [Fact]
+        public void Properties_ValueMap_typed()
+        {
+            g
+                .V()
+                .Properties()
+                .ValueMap<string>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().valueMap()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Properties_ValueMap_untyped()
+        {
+            g
+                .V()
+                .Properties()
+                .ValueMap()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().valueMap()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Properties_Values_Id()
+        {
+            g
+                .V()
+                .Properties()
+                .Values(x => x.Id)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().id()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Properties_Values_Id_Label()
+        {
+            g
+                .V()
+                .Properties()
+                .Values(
+                    x => x.Label,
+                    x => x.Id)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().union(__.label(), __.id())")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Properties_Values_Label()
+        {
+            g
+                .V()
+                .Properties()
+                .Values(x => x.Label)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().label()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Properties_Values_untyped()
+        {
+            g
+                .V()
+                .Properties()
+                .Values()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().values()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Properties_Values2()
+        {
+            g
+                .V()
+                .Properties()
+                .Values<int>("MetaProperty")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().values(_a)")
+                .WithParameters("MetaProperty");
+        }
+
+        [Fact]
+        public void Properties_Where_Dictionary_key1()
+        {
+            g
+                .V<Person>()
+                .Properties()
+                .Where(x => x.Properties["MetaKey"] == "MetaValue")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties().has(_b, _c)")
+                .WithParameters("Person", "MetaKey", "MetaValue");
+        }
+
+        [Fact]
+        public void Properties_Where_Dictionary_key2()
+        {
+            g
+                .V<Person>()
+                .Properties()
+                .Where(x => (int)x.Properties["MetaKey"] < 100)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties().has(_b, lt(_c))")
+                .WithParameters("Person", "MetaKey", 100);
+        }
+
+        [Fact]
+        public void Properties_Where_Id()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Languages)
+                .Where(x => x.Id == "id")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).has(id, _c)")
+                .WithParameters("Country", "Languages", "id");
+        }
+
+        [Fact]
+        public void Properties_Where_Label()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Languages)
+                .Where(x => x.Label == "label")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).where(__.label().is(_c))")
+                .WithParameters("Country", "Languages", "label");
+        }
+
+        [Fact]
+        public void Properties_Where_Meta_key()
+        {
+            g
+                .V<Company>()
+                .Properties(x => x.Name)
+                .Where(x => x.Properties.ValidFrom == DateTimeOffset.Parse("01.01.2019 08:00"))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).has(_c, _d)")
+                .WithParameters("Company", "Name", "ValidFrom", DateTimeOffset.Parse("01.01.2019 08:00"));
+        }
+
+        [Fact]
+        public void Properties_Where_Meta_key_reversed()
+        {
+            g
+                .V<Company>()
+                .Properties(x => x.Name)
+                .Where(x => DateTimeOffset.Parse("01.01.2019 08:00") == x.Properties.ValidFrom)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).has(_c, _d)")
+                .WithParameters("Company", "Name", "ValidFrom", DateTimeOffset.Parse("01.01.2019 08:00"));
+        }
+
+        [Fact]
+        public void Properties_Where_reversed()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Languages)
+                .Where(x => "de" == x.Value)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).hasValue(_c)")
+                .WithParameters("Country", "Languages", "de");
+        }
+
+        [Fact]
+        public void Properties_Where1()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Languages)
+                .Where(x => x.Value == "de")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).hasValue(_c)")
+                .WithParameters("Country", "Languages", "de");
+        }
+
+        [Fact]
+        public void Properties_Where2()
+        {
+            g
+                .V<Country>()
+                .Properties()
+                .Where(x => (int)x.Value < 10)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties().hasValue(lt(_b))")
+                .WithParameters("Country", 10);
+        }
+
+        [Fact]
+        public void Properties_name_untyped()
+        {
+            g
+                .V()
+                .Properties("propertyName")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties(_a)")
+                .WithParameters("propertyName");
+        }
+
+        [Fact]
+        public void Properties_name_typed()
+        {
+            g
+                .V()
+                .Properties<int>("propertyName")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties(_a)")
+                .WithParameters("propertyName");
+        }
+
+
+        [Fact]
+        public void Properties1()
+        {
+            g
+                .V()
+                .Properties()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Properties_typed_no_parameters()
+        {
+            g
+                .V()
+                .Properties<string>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties()")
+                .WithoutParameters();
+        }
+
+
+        [Fact]
+        public void Properties2()
+        {
+            g
+                .E()
+                .Properties()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E().properties()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Variable_wrap()
+        {
+            g
+                .V()
+                .Properties()
+                .Properties("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().properties(_a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _ba, _bb, _bc, _bd)")
+                .WithParameters("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30");
+        }
+
+        [Fact]
+        public void Property_list()
+        {
+            g
+                .V<Company>("id")
+                .Property(x => x.PhoneNumbers, "+4912345")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V(_a).hasLabel(_b).property(list, _c, _d)")
+                .WithParameters("id", "Company", "PhoneNumbers", "+4912345");
+        }
+
+        [Fact]
+        public void Property_null()
+        {
+            g
+                .V<Company>("id")
+                .Property<string>(x => x.PhoneNumbers, null)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V(_a).hasLabel(_b).sideEffect(__.properties(_c).drop())")
+                .WithParameters("id", "Company", "PhoneNumbers");
+        }
+
+        [Fact]
+        public void Property_single()
+        {
+            g
+                .V<Person>()
+                .Property(x => x.Age, 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).property(single, _b, _c)")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Repeat_Out()
+        {
+            g
+                .V<Person>()
+                .Repeat(__ => __
+                    .Out<WorksFor>()
+                    .OfType<Person>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).repeat(__.out(_b).hasLabel(_a))")
+                .WithParameters("Person", "WorksFor");
+        }
+
+        [Fact]
+        public void Select()
+        {
+            var stepLabel = new StepLabel<Person>();
+
+            g
+                .V<Person>()
+                .As(stepLabel)
+                .Select(stepLabel)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).as(_b).select(_b)")
+                .WithParameters("Person", "l1");
+        }
+
+        [Fact]
+        public void Set_Meta_Property1()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name)
+                .Property("metaKey", 1)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).property(_c, _d)")
+                .WithParameters("Country", "Name", "metaKey", 1);
+        }
+
+        [Fact]
+        public void Set_Meta_Property2()
+        {
+            var d = DateTimeOffset.Now;
+
+            g
+                .V<Person>()
+                .Properties(x => x.Name)
+                .Property(x => x.ValidFrom, d)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).property(_c, _d)")
+                .WithParameters("Person", "Name", "ValidFrom", d);
+        }
+
+        [Fact]
+        public void Set_Meta_Property_to_null()
+        {
+            g
+                .V<Country>()
+                .Properties(x => x.Name)
+                .Property("metaKey", null)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).properties(_b).sideEffect(__.properties(_c).drop())")
+                .WithParameters("Country", "Name", "metaKey");
+        }
+
+        [Fact]
+        public void SumGlobal()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Age)
+                .SumGlobal()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b).sum(global)")
+                .WithParameters("Person", "Age");
+        }
+
+        [Fact]
+        public void SumLocal()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Age)
+                .SumLocal()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b).sum(local)")
+                .WithParameters("Person", "Age");
+        }
+
+
+        [Fact]
+        public void SumLocal_Where1()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Age)
+                .SumLocal()
+                .Where(x => x == 100)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b).sum(local).is(_c)")
+                .WithParameters("Person", "Age", 100);
+        }
+
+        [Fact]
+        public void SumLocal_Where2()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Age)
+                .SumLocal()
+                .Where(x => x < 100)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b).sum(local).is(lt(_c))")
+                .WithParameters("Person", "Age", 100);
+        }
+
+        [Fact]
+        public void Tail_underflow()
+        {
+            g
+                .V()
+                .Invoking(_ => _.Tail(-1))
+                .Should()
+                .Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void TailGlobal()
+        {
+            g
+                .V()
+                .Tail(1)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().tail(_a)")
+                .WithParameters(1);
+        }
+
+        [Fact]
+        public void TailLocal()
+        {
+            g
+                .V()
+                .TailLocal(1)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().tail(local, _a)")
+                .WithParameters(1);
+        }
+
+        [Fact]
+        public void Union()
+        {
+            g
+                .V<Person>()
+                .Union(
+                    __ => __.Out<WorksFor>(),
+                    __ => __.Out<LivesIn>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).union(__.out(_b), __.out(_c))")
+                .WithParameters("Person", "WorksFor", "LivesIn");
+        }
+
+        [Fact]
+        public void Union_untyped()
+        {
+            IVertexGremlinQuery q = g
+                .V<Person>();
+
+            q
+                .Union(
+                    __ => __,
+                    __ => __.Out<LivesIn>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).union(__.identity(), __.out(_b))")
+                .WithParameters("Person", "LivesIn");
+        }
+
+        [Fact]
+        public void V_of_abstract_type()
+        {
+            g
+                .V<Authority>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a, _b)")
+                .WithParameters("Company", "Person");
+        }
+
+        [Fact]
+        public void V_of_all_types1()
+        {
+            g
+                .V<object>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void V_of_all_types2()
+        {
+            g
+                .V<IVertex>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void V_of_concrete_type()
+        {
+            g
+                .V<Person>()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a)")
+                .WithParameters("Person");
+        }
+
+        [Fact]
+        public void V_of_type_outside_model()
+        {
+            g
+                .WithModel(GraphModel.Dynamic())
+                .Invoking(_ => _
+                    .V<string>())
+                .Should()
+                .Throw<GraphModelException>();
+        }
+
+        [Fact]
+        public void V_untyped()
+        {
+            g
+                .V()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void Value()
+        {
+            g
+                .V()
+                .Properties()
+                .Value()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().properties().value()");
+        }
+
+        [Fact]
+        public void ValueMap_typed()
+        {
+            g
+                .V<Person>()
+                .ValueMap(x => x.Age)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).valueMap(_b)")
+                .WithParameters("Person", "Age");
+        }
+
+        [Fact]
+        public void ValueMap_untyped()
+        {
+            g
+                .V<Person>()
+                .ValueMap("key")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).valueMap(_b)")
+                .WithParameters("Person", "key");
+        }
+
+        [Fact]
+        public void Values_1_member()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Age)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b)")
+                .WithParameters("Person", "Age");
+        }
+
+        [Fact]
+        public void Values_2_members()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Name, x => x.Id)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).union(__.id(), __.values(_b))")
+                .WithParameters("Person", "Name");
+        }
+
+        [Fact]
+        public void Values_3_members()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Name, x => x.Gender, x => x.Id)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).union(__.id(), __.values(_b, _c))")
+                .WithParameters("Person", "Name", "Gender");
+        }
+
+        [Fact]
+        public void Values_id_member()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Id)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).id()")
+                .WithParameters("Person");
+        }
+
+        [Fact]
+        public void Values_no_member()
+        {
+            g
+                .V<Person>()
+                .Values()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values()")
+                .WithParameters("Person");
+        }
+
+        [Fact]
+        public void Values_of_Edge()
+        {
+            g
+                .E<LivesIn>()
+                .Values(x => x.Since)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E().hasLabel(_a).values(_b)")
+                .WithParameters("LivesIn", "Since");
+        }
+
+        [Fact]
+        public void Values_of_Vertex1()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Name)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b)")
+                .WithParameters("Person", "Name");
+        }
+
+        [Fact]
+        public void Values_of_Vertex2()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Name)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b)")
+                .WithParameters("Person", "Name");
+        }
+
+        [Fact]
+        public void Values_string_key()
+        {
+            g
+                .V<Person>()
+                .Values("key")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b)")
+                .WithParameters("Person", "key");
+        }
+
+        [Fact]
+        public void Where_array_does_not_intersect_property_array()
+        {
+            g
+                .V<Company>()
+                .Where(t => !new[] { "+4912345", "+4923456" }.Intersect(t.PhoneNumbers).Any())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).not(__.has(_b, within(_c, _d)))")
+                .WithParameters("Company", "PhoneNumbers", "+4912345", "+4923456");
+        }
+
+        [Fact]
+        public void Where_array_intersects_property_aray()
+        {
+            g
+                .V<Company>()
+                .Where(t => new[] { "+4912345", "+4923456" }.Intersect(t.PhoneNumbers).Any())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, within(_c, _d))")
+                .WithParameters("Company", "PhoneNumbers", "+4912345", "+4923456");
+        }
+
+        [Fact]
+        public void Where_bool_property_explicit_comparison1()
+        {
+            g
+                .V<TimeFrame>()
+                // ReSharper disable once RedundantBoolCompare
+                .Where(t => t.Enabled == true)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c)")
+                .WithParameters("TimeFrame", "Enabled", true);
+        }
+
+        [Fact]
+        public void Where_bool_property_explicit_comparison2()
+        {
+            g
+                .V<TimeFrame>()
+                .Where(t => t.Enabled == false)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c)")
+                .WithParameters("TimeFrame", "Enabled", false);
+        }
+
+        [Fact]
+        public void Where_bool_property_implicit_comparison1()
+        {
+            g
+                .V<TimeFrame>()
+                .Where(t => t.Enabled)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c)")
+                .WithParameters("TimeFrame", "Enabled", true);
+        }
+
+        [Fact]
+        public void Where_bool_property_implicit_comparison2()
+        {
+            g
+                .V<TimeFrame>()
+                .Where(t => !t.Enabled)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).not(__.has(_b, _c))")
+                .WithParameters("TimeFrame", "Enabled", true);
+        }
+
+        [Fact]
+        public void Where_complex_logical_expression()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Name.Value == "Some name" && (t.Age == 42 || t.Age == 99))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c).has(_d, eq(_e).or(eq(_f)))")
+                .WithParameters("Person", "Name", "Some name", "Age", 42, 99);
+        }
+
+        [Fact]
+        public void Where_complex_logical_expression_with_null()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Name == null && (t.Age == 42 || t.Age == 99))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).hasNot(_b).has(_c, eq(_d).or(eq(_e)))")
+                .WithParameters("Person", "Name", "Age", 42, 99);
+        }
+
+        [Fact]
+        public void Where_conjunction()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Age == 36 && t.Age == 42)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, eq(_c).and(eq(_d)))")
+                .WithParameters("Person", "Age", 36, 42);
+        }
+
+        [Fact(Skip = "Optimizable")]
+        public void Where_conjunction_optimizable()
+        {
+            g
+                .V<Person>()
+                .Where(t => (t.Age == 36 && t.Name.Value == "Hallo") && t.Age == 42)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, eq(_c).and(eq(_d))).has(_b, eq(_e))")
+                .WithParameters("Person", "Age", 36, "Name", 42);
+        }
+
+        [Fact]
+        public void Where_conjunction_with_different_fields()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Name.Value == "Some name" && t.Age == 42)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c).has(_d, _e)")
+                .WithParameters("Person", "Name", "Some name", "Age", 42);
+        }
+
+        [Fact]
+        public void Where_converted_Id_equals_constant()
+        {
+            g
+                .V<Language>()
+                .Where(t => (int)t.Id == 1)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(id, _b)")
+                .WithParameters("Language", 1);
+        }
+
+        [Fact]
+        public void Where_current_element_equals_stepLabel()
+        {
+            var l = new StepLabel<Language>();
+
+            g
+                .V<Language>()
+                .As(l)
+                .V<Language>()
+                .Where(l2 => l2 == l)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).as(_b).V().hasLabel(_a).where(eq(_b))")
+                .WithParameters("Language", "l1");
+        }
+
+        [Fact]
+        public void Where_disjunction()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Age == 36 || t.Age == 42)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, eq(_c).or(eq(_d)))")
+                .WithParameters("Person", "Age", 36, 42);
+        }
+
+        [Fact]
+        public void Where_disjunction_with_different_fields()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Name.Value == "Some name" || t.Age == 42)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).or(__.has(_b, _c), __.has(_d, _e))")
+                .WithParameters("Person", "Name", "Some name", "Age", 42);
+        }
+
+        [Fact]
+        public void Where_empty_array_does_not_intersect_property_array()
+        {
+            g
+                .V<Company>()
+                .Where(t => !new string[0].Intersect(t.PhoneNumbers).Any())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a)")
                 .WithParameters("Company");
         }
-        
+
         [Fact]
-        public void Where_property_is_contained_in_empty_enumerable()
+        public void Where_has_conjunction_of_three()
         {
-            var enumerable = Enumerable.Empty<int>();
+            g
+                .V<Person>()
+                .Where(t => t.Age == 36 && t.Age == 42 && t.Age == 99)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, eq(_c).and(eq(_d)).and(eq(_e)))")
+                .WithParameters("Person", "Age", 36, 42, 99);
+        }
+
+        [Fact]
+        public void Where_has_disjunction_of_three()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Age == 36 || t.Age == 42 || t.Age == 99)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, eq(_c).or(eq(_d)).or(eq(_e)))")
+                .WithParameters("Person", "Age", 36, 42, 99);
+        }
+
+        [Fact]
+        public void Where_Id_equals_constant()
+        {
+            g
+                .V<Language>()
+                .Where(t => t.Id == (object)1)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(id, _b)")
+                .WithParameters("Language", 1);
+        }
+
+        [Fact]
+        public void Where_property_array_contains_element()
+        {
+            g
+                .V<Company>()
+                .Where(t => t.PhoneNumbers.Contains("+4912345"))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c)")
+                .WithParameters("Company", "PhoneNumbers", "+4912345");
+        }
+
+        [Fact]
+        public void Where_property_array_contains_stepLabel()
+        {
+            g
+                .Inject("+4912345")
+                .As((__, t) => __
+                    .V<Company>()
+                    .Where(c => c.PhoneNumbers.Contains(t)))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.inject(_a).as(_b).V().hasLabel(_c).has(_d, __.where(eq(_b)))")
+                .WithParameters("+4912345", "l1", "Company", "PhoneNumbers");
+        }
+
+        [Fact]
+        public void Where_property_array_does_not_contain_element()
+        {
+            g
+                .V<Company>()
+                .Where(t => !t.PhoneNumbers.Contains("+4912345"))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).not(__.has(_b, _c))")
+                .WithParameters("Company", "PhoneNumbers", "+4912345");
+        }
+
+        [Fact]
+        public void Where_property_array_does_not_intersect_array()
+        {
+            g
+                .V<Company>()
+                .Where(t => !t.PhoneNumbers.Intersect(new[] { "+4912345", "+4923456" }).Any())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).not(__.has(_b, within(_c, _d)))")
+                .WithParameters("Company", "PhoneNumbers", "+4912345", "+4923456");
+        }
+
+        [Fact]
+        public void Where_property_array_does_not_intersect_empty_array()
+        {
+            g
+                .V<Company>()
+                .Where(t => !t.PhoneNumbers.Intersect(new string[0]).Any())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a)")
+                .WithParameters("Company");
+        }
+
+        [Fact]
+        public void Where_property_array_intersects_aray()
+        {
+            g
+                .V<Company>()
+                .Where(t => t.PhoneNumbers.Intersect(new[] { "+4912345", "+4923456" }).Any())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, within(_c, _d))")
+                .WithParameters("Company", "PhoneNumbers", "+4912345", "+4923456");
+        }
+
+        [Fact]
+        public void Where_property_array_is_empty()
+        {
+            g
+                .V<Company>()
+                .Where(t => !t.PhoneNumbers.Any())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).not(__.has(_b))")
+                .WithParameters("Company", "PhoneNumbers");
+        }
+
+        [Fact]
+        public void Where_property_array_is_not_empty()
+        {
+            g
+                .V<Company>()
+                .Where(t => t.PhoneNumbers.Any())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b)")
+                .WithParameters("Company", "PhoneNumbers");
+        }
+
+        [Fact]
+        public void Where_property_equals_constant()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Age == 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c)")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_property_equals_converted_expression()
+        {
+            g
+                .V<Person>()
+                .Where(t => (object)t.Age == (object)36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c)")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_property_equals_expression()
+        {
+            const int i = 18;
+
+            g
+                .V<Person>()
+                .Where(t => t.Age == i + i)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c)")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_property_equals_local_string_constant()
+        {
+            const int local = 1;
+
+            g
+                .V<Language>()
+                .Where(t => t.Id == (object)local)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(id, _b)")
+                .WithParameters("Language", local);
+        }
+
+        [Fact]
+        public void Where_property_equals_stepLabel()
+        {
+            var l = new StepLabel<string>();
+
+            g
+                .V<Language>()
+                .Values(x => x.IetfLanguageTag)
+                .As(l)
+                .V<Language>()
+                .Where(l2 => l2.IetfLanguageTag == l)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b).as(_c).V().hasLabel(_a).has(_b, __.where(eq(_c)))")
+                .WithParameters("Language", "IetfLanguageTag", "l1");
+        }
+
+        [Fact]
+        public void Where_property_equals_value_of_anonymous_object()
+        {
+            var local = new { Value = 1 };
+
+            g
+                .V<Language>()
+                .Where(t => t.Id == (object)local.Value)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(id, _b)")
+                .WithParameters("Language", 1);
+        }
+
+        [Fact]
+        public void Where_property_is_contained_in_array()
+        {
+            g
+                .V<Person>()
+                .Where(t => new[] { 36, 37, 38 }.Contains(t.Age))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, within(_c, _d, _e))")
+                .WithParameters("Person", "Age", 36, 37, 38);
+        }
+
+        [Fact]
+        public void Where_property_is_contained_in_enumerable()
+        {
+            var enumerable = new[] { "36", "37", "38" }
+                .Select(int.Parse);
 
             g
                 .V<Person>()
                 .Where(t => enumerable.Contains(t.Age))
                 .Should()
-                .SerializeToGroovy<CosmosDbGroovyGremlinQueryElementVisitor>("g.V().hasLabel(_a).not(__.identity())")
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, within(_c, _d, _e))")
+                .WithParameters("Person", "Age", 36, 37, 38);
+        }
+
+        [Fact]
+        public void Where_property_is_greater_or_equal_than_constant()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Age >= 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, gte(_c))")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_property_is_greater_than_constant()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Age > 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, gt(_c))")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_property_is_lower_or_equal_than_constant()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Age <= 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, lte(_c))")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_property_is_lower_than_constant()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Age < 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, lt(_c))")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_property_is_not_contained_in_array()
+        {
+            g
+                .V<Person>()
+                .Where(t => !new[] { 36, 37, 38 }.Contains(t.Age))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).not(__.has(_b, within(_c, _d, _e)))")
+                .WithParameters("Person", "Age", 36, 37, 38);
+        }
+
+        [Fact]
+        public void Where_property_is_not_contained_in_empty_enumerable()
+        {
+            var enumerable = Enumerable.Empty<int>();
+
+            g
+                .V<Person>()
+                .Where(t => !enumerable.Contains(t.Age))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a)")
                 .WithParameters("Person");
+        }
+
+        [Fact]
+        public void Where_property_is_not_contained_in_enumerable()
+        {
+            var enumerable = new[] { "36", "37", "38" }
+                .Select(int.Parse);
+
+            g
+                .V<Person>()
+                .Where(t => !enumerable.Contains(t.Age))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).not(__.has(_b, within(_c, _d, _e)))")
+                .WithParameters("Person", "Age", 36, 37, 38);
+        }
+
+        [Fact]
+        public void Where_property_is_not_present()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Name == null)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).hasNot(_b)")
+                .WithParameters("Person", "Name");
+        }
+
+        [Fact]
+        public void Where_property_is_prefix_of_constant()
+        {
+            g
+                .V<Country>()
+                .Where(c => "+49123".StartsWith(c.CountryCallingCode))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, within(_c, _d, _e, _f, _g, _h, _i))")
+                .WithParameters("Country", "CountryCallingCode", "", "+", "+4", "+49", "+491", "+4912", "+49123");
+        }
+
+        [Fact]
+        public void Where_property_is_prefix_of_empty_string()
+        {
+            g
+                .V<Country>()
+                .Where(c => "".StartsWith(c.CountryCallingCode))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, within(_c))")
+                .WithParameters("Country", "CountryCallingCode", "");
+        }
+
+        [Fact]
+        public void Where_property_is_prefix_of_expression()
+        {
+            const string str = "+49123xxx";
+
+            g
+                .V<Country>()
+                .Where(c => str.Substring(0, 6).StartsWith(c.CountryCallingCode))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, within(_c, _d, _e, _f, _g, _h, _i))")
+                .WithParameters("Country", "CountryCallingCode", "", "+", "+4", "+49", "+491", "+4912", "+49123");
+        }
+
+        [Fact]
+        public void Where_property_is_prefix_of_variable()
+        {
+            const string str = "+49123";
+
+            g
+                .V<Country>()
+                .Where(c => str.StartsWith(c.CountryCallingCode))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, within(_c, _d, _e, _f, _g, _h, _i))")
+                .WithParameters("Country", "CountryCallingCode", "", "+", "+4", "+49", "+491", "+4912", "+49123");
+        }
+
+        [Fact]
+        public void Where_property_is_present()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Name != null)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b)")
+                .WithParameters("Person", "Name");
+        }
+
+        [Fact]
+        public void Where_property_not_equals_constant()
+        {
+            g
+                .V<Person>()
+                .Where(t => t.Age != 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, neq(_c))")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_property_starts_with_constant()
+        {
+            g
+                .V<Country>()
+                .Where(c => c.CountryCallingCode.StartsWith("+49123"))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, between(_c, _d))")
+                .WithParameters("Country", "CountryCallingCode", "+49123", "+49124");
+        }
+
+        [Fact]
+        public void Where_property_starts_with_empty_string()
+        {
+            g
+                .V<Country>()
+                .Where(c => c.CountryCallingCode.StartsWith(""))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b)")
+                .WithParameters("Country", "CountryCallingCode");
+        }
+
+        [Fact]
+        public void Where_property_traversal()
+        {
+            g
+                .V<Person>()
+                .Where(
+                    x => x.Age,
+                    _ => _
+                        .Inject(36))
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, __.inject(_c))")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_scalar_element_equals_constant()
+        {
+            g
+                .V<Person>()
+                .Values(x => x.Age)
+                .Where(_ => _ == 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).values(_b).is(_c)")
+                .WithParameters("Person", "Age", 36);
+        }
+
+        [Fact]
+        public void Where_source_expression_on_both_sides()
+        {
+            g
+                .V<Country>()
+                .Invoking(query => query.Where(t => t.Name.Value == t.CountryCallingCode))
+                .Should()
+                .Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void Where_traversal()
+        {
+            g
+                .V<Person>()
+                .Where(_ => _.Out<LivesIn>())
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).where(__.out(_b))")
+                .WithParameters("Person", "LivesIn");
+        }
+
+        [Fact]
+        public void Where_VertexProperty_Value1()
+        {
+            g
+                .V<Person>()
+                .Where(x => x.Name.Value == "SomeName")
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, _c)")
+                .WithParameters("Person", "Name", "SomeName");
+        }
+
+        [Fact]
+        public void Where_VertexProperty_Value2()
+        {
+            g
+                .V<Person>()
+                .Where(x => ((int)(object)x.Name.Value) > 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, gt(_c))")
+                .WithParameters("Person", "Name", 36);
+        }
+
+        [Fact(Skip = "Feature!")]
+        public void Where_VertexProperty_Value3()
+        {
+            g
+                .V<Person>()
+                .Where(x => (int)x.Name.Id == 36)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).has(_b, gt(_c))")
+                .WithParameters("Person", "Name", 36);
+        }
+
+        [Fact]
+        public void WithSubgraphStrategy()
+        {
+            g
+                .WithStrategies(new SubgraphQueryStrategy(_ => _.OfType<Person>(), _ => _.OfType<WorksFor>()))
+                .V()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.withStrategies(SubgraphStrategy.build().vertices(__.hasLabel(_a)).edges(__.hasLabel(_b)).create()).V()")
+                .WithParameters("Person", "WorksFor");
+        }
+
+        [Fact]
+        public void WithSubgraphStrategy_empty()
+        {
+            g
+                .WithStrategies(new SubgraphQueryStrategy(_ => _, _ => _))
+                .V()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void WithSubgraphStrategy_only_edges()
+        {
+            g
+                .WithStrategies(new SubgraphQueryStrategy(_ => _, _ => _.OfType<WorksFor>()))
+                .V()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.withStrategies(SubgraphStrategy.build().edges(__.hasLabel(_a)).create()).V()")
+                .WithParameters("WorksFor");
+        }
+
+        [Fact]
+        public void WithSubgraphStrategy_only_vertices()
+        {
+            g
+                .WithStrategies(new SubgraphQueryStrategy(_ => _.OfType<Person>(), _ => _))
+                .V()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.withStrategies(SubgraphStrategy.build().vertices(__.hasLabel(_a)).create()).V()")
+                .WithParameters("Person");
+        }
+
+        [Fact]
+        public void WithoutStrategies1()
+        {
+            g
+                .WithoutStrategies("ReferenceElementStrategy")
+                .V()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.withoutStrategies(ReferenceElementStrategy).V()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void WithoutStrategies2()
+        {
+            g
+                .WithoutStrategies("ReferenceElementStrategy", "SomeOtherStrategy")
+                .V()
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.withoutStrategies(ReferenceElementStrategy, SomeOtherStrategy).V()")
+                .WithoutParameters();
+        }
+
+        [Fact]
+        public void UpdateV_No_Config()
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            g
+                .V<Person>()
+                .UpdateV(new Person { Age = 21, Gender = Gender.Male, Name = "Marko", RegistrationDate = now })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).sideEffect(__.properties(_b, _c, _d, _e).drop()).property(single, _b, _f).property(single, _c, _g).property(single, _d, _h).property(single, _e, _i)")
+                .WithParameters(nameof(Person), nameof(Person.Age), nameof(Person.Name), nameof(Person.Gender),
+                    nameof(Person.RegistrationDate), 21, "Marko", Gender.Male, now);
+        }
+
+        [Fact]
+        public void UpdateV_With_Readonly()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var person = new Person { Age = 21, Gender = Gender.Male, Name = "Marko", RegistrationDate = now };
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<Person>()
+                    .ReadOnly(p => p.Age)
+                    .ReadOnly(p => p.Gender);
+            });
+
+            local
+                .V<Person>()
+                .UpdateV(person)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).sideEffect(__.properties(_b, _c).drop()).property(single, _b, _d).property(single, _c, _e)")
+                .WithParameters(nameof(Person), nameof(Person.Name), nameof(Person.RegistrationDate), "Marko", now);
+        }
+
+        [Fact]
+        public void UpdateV_With_Ignored()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var person = new Person { Age = 21, Gender = Gender.Male, Name = "Marko", RegistrationDate = now };
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<Person>()
+                    .Ignored(p => p.Age)
+                    .Ignored(p => p.Gender);
+            });
+
+            local
+                .V<Person>()
+                .UpdateV(person)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).sideEffect(__.properties(_b, _c).drop()).property(single, _b, _d).property(single, _c, _e)")
+                .WithParameters(nameof(Person), nameof(Person.Name), nameof(Person.RegistrationDate), "Marko", now);
+        }
+
+        [Fact]
+        public void UpdateV_With_Mixed()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var person = new Person { Age = 21, Gender = Gender.Male, Name = "Marko", RegistrationDate = now };
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<Person>()
+                    .ReadOnly(p => p.Age)
+                    .Ignored(p => p.Gender);
+            });
+
+            local
+                .V<Person>()
+                .UpdateV(person)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).sideEffect(__.properties(_b, _c).drop()).property(single, _b, _d).property(single, _c, _e)")
+                .WithParameters(nameof(Person), nameof(Person.Name), nameof(Person.RegistrationDate), "Marko", now);
+        }
+
+        [Fact]
+        public void UpdateE_No_Config()
+        {
+            var now = DateTime.UtcNow;
+
+            g
+                .E<WorksFor>()
+                .UpdateE(new WorksFor { From = now, To = now, Role = "Admin" })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E().hasLabel(_a).sideEffect(__.properties(_b, _c, _d).drop()).property(_b, _e).property(_c, _f).property(_d, _f)")
+                .WithParameters(nameof(WorksFor), nameof(WorksFor.Role), nameof(WorksFor.From), nameof(WorksFor.To), "Admin", now);
+        }
+
+        [Fact]
+        public void UpdateE_With_Readonly()
+        {
+            var now = DateTime.UtcNow;
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<WorksFor>()
+                    .ReadOnly(p => p.From)
+                    .ReadOnly(p => p.Role);
+            });
+
+            local
+                .E<WorksFor>()
+                .UpdateE(new WorksFor { From = now, To = now, Role = "Admin" })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E().hasLabel(_a).sideEffect(__.properties(_b).drop()).property(_b, _c)")
+                .WithParameters(nameof(WorksFor), nameof(WorksFor.To), now);
+        }
+
+        [Fact]
+        public void UpdateE_With_Ignored()
+        {
+            var now = DateTime.UtcNow;
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<WorksFor>()
+                    .Ignored(p => p.From)
+                    .Ignored(p => p.Role);
+            });
+
+            local
+                .E<WorksFor>()
+                .UpdateE(new WorksFor { From = now, To = now, Role = "Admin" })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E().hasLabel(_a).sideEffect(__.properties(_b).drop()).property(_b, _c)")
+                .WithParameters(nameof(WorksFor), nameof(WorksFor.To), now);
+        }
+
+        [Fact]
+        public void UpdateE_With_Mixed()
+        {
+            var now = DateTime.UtcNow;
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<WorksFor>()
+                    .Ignored(p => p.From)
+                    .ReadOnly(p => p.Role);
+            });
+
+            local
+                .E<WorksFor>()
+                .UpdateE(new WorksFor { From = now, To = now, Role = "Admin" })
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E().hasLabel(_a).sideEffect(__.properties(_b).drop()).property(_b, _c)")
+                .WithParameters(nameof(WorksFor), nameof(WorksFor.To), now);
+        }
+
+        [Fact]
+        public void Update_Vertex_And_Edge_With_Config()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var edgeNow = DateTime.UtcNow;
+            var person = new Person { Age = 21, Gender = Gender.Male, Name = "Marko", RegistrationDate = now };
+            var worksFor = new WorksFor { From = edgeNow, To = edgeNow, Role = "Admin" };
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<Person>()
+                    .Ignored(p => p.Name)
+                    .ReadOnly(p => p.Age);
+
+                builder.Element<WorksFor>()
+                    .Ignored(p => p.From)
+                    .ReadOnly(p => p.Role);
+            });
+
+            local
+                .V<Person>()
+                .UpdateV(person)
+                .OutE<WorksFor>()
+                .UpdateE(worksFor)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).sideEffect(__.properties(_b, _c).drop()).property(single, _b, _d).property(single, _c, _e).outE(_f).sideEffect(__.properties(_g).drop()).property(_g, _h)")
+                .WithParameters(nameof(Person),
+                    nameof(Person.Gender), nameof(Person.RegistrationDate),
+                    person.Gender, person.RegistrationDate,
+                    nameof(WorksFor), nameof(WorksFor.To),
+                    worksFor.To);
+        }
+
+        [Fact]
+        public void Update_Vertex_And_Edge_No_Config()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var edgeNow = DateTime.UtcNow;
+            var person = new Person { Age = 21, Gender = Gender.Male, Name = "Marko", RegistrationDate = now };
+            var worksFor = new WorksFor { From = edgeNow, To = edgeNow, Role = "Admin" };
+
+            g
+                .V<Person>()
+                .UpdateV(person)
+                .OutE<WorksFor>()
+                .UpdateE(worksFor)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V().hasLabel(_a).sideEffect(__.properties(_b, _c, _d, _e).drop()).property(single, _b, _f).property(single, _c, _g).property(single, _d, _h).property(single, _e, _i).outE(_j).sideEffect(__.properties(_k, _l, _m).drop()).property(_k, _n).property(_l, _o).property(_m, _o)")
+                .WithParameters(nameof(Person),
+                    nameof(Person.Age), nameof(Person.Name), nameof(Person.Gender), nameof(Person.RegistrationDate),
+                    person.Age, "Marko", person.Gender, person.RegistrationDate,
+                    nameof(WorksFor), nameof(WorksFor.Role), nameof(WorksFor.From), nameof(WorksFor.To),
+                    worksFor.Role, worksFor.From);
+        }
+
+        [Fact]
+        public void ReplaceV()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var id = Guid.NewGuid();
+            var person = new Person { Id = id, Age = 21, Gender = Gender.Male, Name = "Marko", RegistrationDate = now };
+            g
+                .ReplaceV(person)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V(_a).sideEffect(__.properties(_b, _c, _d, _e, _f).drop()).property(id, _a).property(single, _b, _g).property(single, _c, _h).property(single, _d, _i).property(single, _e, _j)")
+                .WithParameters(id, nameof(Person.Age), nameof(Person.Name), nameof(Person.Gender),
+                    nameof(Person.RegistrationDate), nameof(Person.Id), 21, "Marko", Gender.Male, now);
+        }
+
+        [Fact]
+        public void ReplaceV_With_Config()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var id = Guid.NewGuid();
+            var person = new Person { Id = id, Age = 21, Gender = Gender.Male, Name = "Marko", RegistrationDate = now };
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<Person>()
+                    .ReadOnly(p => p.Id);
+            });
+
+            local
+                .ReplaceV(person)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.V(_a).sideEffect(__.properties(_b, _c, _d, _e).drop()).property(single, _b, _f).property(single, _c, _g).property(single, _d, _h).property(single, _e, _i)")
+                .WithParameters(id, nameof(Person.Age), nameof(Person.Name), nameof(Person.Gender),
+                    nameof(Person.RegistrationDate), 21, "Marko", Gender.Male, now);
+        }
+
+        [Fact]
+        public void ReplaceE()
+        {
+            var now = DateTime.UtcNow;
+            var id = Guid.NewGuid();
+
+            var worksFor = new WorksFor { Id = id, From = now, To = now, Role = "Admin" };
+
+            g
+                .ReplaceE(worksFor)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E(_a).sideEffect(__.properties(_b, _c, _d, _e).drop()).property(id, _a).property(_b, _f).property(_c, _g).property(_d, _g)")
+                .WithParameters(id, nameof(WorksFor.Role), nameof(WorksFor.From), nameof(WorksFor.To), nameof(WorksFor.Id), "Admin", now);
+        }
+
+        [Fact]
+        public void ReplaceE_With_Config()
+        {
+            var now = DateTime.UtcNow;
+            var id = Guid.NewGuid();
+
+            var worksFor = new WorksFor { Id = id, From = now, To = now, Role = "Admin" };
+
+            var local = Create();
+
+            local.Model.Configure(builder =>
+            {
+                builder.Element<WorksFor>()
+                    .ReadOnly(p => p.Id);
+            });
+
+            local
+                .ReplaceE(worksFor)
+                .Should()
+                .SerializeToGroovy<TVisitor>("g.E(_a).sideEffect(__.properties(_b, _c, _d).drop()).property(_b, _e).property(_c, _f).property(_d, _f)")
+                .WithParameters(id, nameof(WorksFor.Role), nameof(WorksFor.From), nameof(WorksFor.To), "Admin", now);
         }
     }
 }


### PR DESCRIPTION
Continuation of PR #11 and requires the changes in #12.

This adds the query methods `UpdateV`, `UpdateE`, `ReplaceV`, and `ReplaceE`. It also updates `AddV` and `AddE` to support Ignored properties in the configuration.
