### PR TITLE
Add QueryAndParametersWithStandardAttributes logging option (#64)

### DIFF
--- a/ApprovalTests/ApprovalTests.WebSocket.verified.cs
+++ b/ApprovalTests/ApprovalTests.WebSocket.verified.cs
@@ -1,4 +1,4 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace ExRam.Gremlinq.Core
 {
     public static class GremlinQueryEnvironmentExtensions
@@ -40,6 +40,7 @@ namespace ExRam.Gremlinq.Providers.WebSocket
         None = 0,
         QueryOnly = 1,
         QueryAndParameters = 2,
+        QueryAndParametersWithStatusAttributes = 3,
     }
     public static class WebSocketConfigurationBuilderExtensions
     {

--- a/ExRam.Gremlinq.Providers.WebSocket/QueryLoggingVerbosity.cs
+++ b/ExRam.Gremlinq.Providers.WebSocket/QueryLoggingVerbosity.cs
@@ -4,6 +4,7 @@
     {
         None = 0,
         QueryOnly = 1,
-        QueryAndParameters,
+        QueryAndParameters = 2,
+        QueryAndParametersWithStatusAttributes = 3
     }
 }


### PR DESCRIPTION
I have a proposal for how to extend the WebSocket provider's executor so that it can log status attributes in the response from Cosmos along with the query. I hope I'm not breaking protocol by forking and submitting a PR; please let me know if you want me to submit this another way.