### PR TITLE
Breaking: UseNeptune takes a transformation from INeptuneConfigurationBuilder

### DIFF
--- a/src/ExRam.Gremlinq.Providers.JanusGraph/GremlinQueryEnvironmentExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.JanusGraph/GremlinQueryEnvironmentExtensions.cs
@@ -5,8 +5,7 @@ namespace ExRam.Gremlinq.Core
 {
     public static class GremlinQueryEnvironmentExtensions
     {
-        public static IGremlinQueryEnvironment UseJanusGraph(this IGremlinQueryEnvironment environment,
-            Func<IWebSocketGremlinQueryExecutorBuilder, IWebSocketGremlinQueryExecutorBuilder> builderAction)
+        public static IGremlinQueryEnvironment UseJanusGraph(this IGremlinQueryEnvironment environment, Func<IWebSocketGremlinQueryExecutorBuilder, IWebSocketGremlinQueryExecutorBuilder> builderAction)
         {
             return environment
                 .UseGremlinServer(builderAction)

--- a/src/ExRam.Gremlinq.Providers.Neptune.AspNet/GremlinqSetupExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.Neptune.AspNet/GremlinqSetupExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,8 +25,11 @@ namespace ExRam.Gremlinq.Core.AspNet
             public IGremlinQueryEnvironment Transform(IGremlinQueryEnvironment environment)
             {
                 return environment
-                    .UseNeptune(builder => builder.Configure(_configuration)
-                        .Transform(_webSocketTransformations));
+                    .UseNeptune(builder => builder
+                        .At(new Uri("ws://localhost:8182"))
+                        .ConfigureWebSocket(_ => _
+                            .Configure(_configuration)
+                            .Transform(_webSocketTransformations)));
             }
         }
 

--- a/src/ExRam.Gremlinq.Providers.Neptune/GremlinQueryEnvironmentExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.Neptune/GremlinQueryEnvironmentExtensions.cs
@@ -4,16 +4,6 @@ using Gremlin.Net.Process.Traversal;
 
 namespace ExRam.Gremlinq.Core
 {
-    public interface INeptuneConfigurationBuilder
-    {
-        INeptuneConfigurationBuilderWithUri At(Uri uri);
-    }
-
-    public interface INeptuneConfigurationBuilderWithUri : IGremlinQueryExecutorBuilder
-    {
-        IGremlinQueryExecutorBuilder ConfigureWebSocket(Func<IWebSocketGremlinQueryExecutorBuilder, IWebSocketGremlinQueryExecutorBuilder> transformation);
-    }
-
     public static class GremlinQueryEnvironmentExtensions
     {
         private sealed class NeptuneConfigurationBuilder :

--- a/src/ExRam.Gremlinq.Providers.Neptune/INeptuneConfigurationBuilder.cs
+++ b/src/ExRam.Gremlinq.Providers.Neptune/INeptuneConfigurationBuilder.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ExRam.Gremlinq.Core
+{
+    public interface INeptuneConfigurationBuilder
+    {
+        INeptuneConfigurationBuilderWithUri At(Uri uri);
+    }
+}

--- a/src/ExRam.Gremlinq.Providers.Neptune/INeptuneConfigurationBuilderWithUri.cs
+++ b/src/ExRam.Gremlinq.Providers.Neptune/INeptuneConfigurationBuilderWithUri.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+using ExRam.Gremlinq.Providers.WebSocket;
+
+namespace ExRam.Gremlinq.Core
+{
+    public interface INeptuneConfigurationBuilderWithUri : IGremlinQueryExecutorBuilder
+    {
+        IGremlinQueryExecutorBuilder ConfigureWebSocket(Func<IWebSocketGremlinQueryExecutorBuilder, IWebSocketGremlinQueryExecutorBuilder> transformation);
+    }
+}

--- a/test/ExRam.Gremlinq.Providers.Neptune.Tests/NeptuneQuerySerializationTest.cs
+++ b/test/ExRam.Gremlinq.Providers.Neptune.Tests/NeptuneQuerySerializationTest.cs
@@ -1,6 +1,6 @@
-﻿using ExRam.Gremlinq.Core;
+﻿using System;
+using ExRam.Gremlinq.Core;
 using ExRam.Gremlinq.Core.Tests;
-using ExRam.Gremlinq.Providers.WebSocket;
 using Xunit.Abstractions;
 using static ExRam.Gremlinq.Core.GremlinQuerySource;
 
@@ -11,7 +11,8 @@ namespace ExRam.Gremlinq.Providers.Neptune.Tests
         public NeptuneQuerySerializationTest(ITestOutputHelper testOutputHelper) : base(
             g
                 .ConfigureEnvironment(env => env
-                    .UseNeptune(builder => builder.AtLocalhost())),
+                    .UseNeptune(builder => builder
+                        .At(new Uri("ws://localhost:8182")))),
             testOutputHelper)
         {
         }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Neptune.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Neptune.verified.cs
@@ -2,6 +2,14 @@ namespace ExRam.Gremlinq.Core
 {
     public static class GremlinQueryEnvironmentExtensions
     {
-        public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment UseNeptune(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, System.Func<ExRam.Gremlinq.Providers.WebSocket.IWebSocketGremlinQueryExecutorBuilder, ExRam.Gremlinq.Providers.WebSocket.IWebSocketGremlinQueryExecutorBuilder> transformation) { }
+        public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment UseNeptune(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, System.Func<ExRam.Gremlinq.Core.INeptuneConfigurationBuilder, ExRam.Gremlinq.Core.IGremlinQueryExecutorBuilder> transformation) { }
+    }
+    public interface INeptuneConfigurationBuilder
+    {
+        ExRam.Gremlinq.Core.INeptuneConfigurationBuilderWithUri At(System.Uri uri);
+    }
+    public interface INeptuneConfigurationBuilderWithUri : ExRam.Gremlinq.Core.IGremlinQueryExecutorBuilder
+    {
+        ExRam.Gremlinq.Core.IGremlinQueryExecutorBuilder ConfigureWebSocket(System.Func<ExRam.Gremlinq.Providers.WebSocket.IWebSocketGremlinQueryExecutorBuilder, ExRam.Gremlinq.Providers.WebSocket.IWebSocketGremlinQueryExecutorBuilder> transformation);
     }
 }


### PR DESCRIPTION
To get the previous behaviour, first call At(Uri) on the builder, then, if needed, configure the rest by calling ConfigureWebSocket(...).