### PR TITLE
ProjectVertexStep and ProjectEdgeStep

### DIFF
--- a/src/ExRam.Gremlinq.Core/Queries/QuerySemantics.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/QuerySemantics.cs
@@ -81,12 +81,12 @@ namespace ExRam.Gremlinq.Core
                             .GetTypeInfo().ImplementedInterfaces
                             .Prepend(other.QueryType);
 
-                        var hightest = impl1
+                        var highest = impl1
                             .Intersect(impl2)
                             .OrderByDescending(x => x, TypeComparer.Instance)
                             .FirstOrDefault();
 
-                        return hightest ?? typeof(IGremlinQueryBase);
+                        return highest ?? typeof(IGremlinQueryBase);
                     });
         }
 

--- a/src/ExRam.Gremlinq.Core/Queries/QuerySemantics.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/QuerySemantics.cs
@@ -58,7 +58,7 @@ namespace ExRam.Gremlinq.Core
 
         public bool Equals(QuerySemantics other) => QueryType == other.QueryType;
 
-        public override int GetHashCode() => -1567131905 + EqualityComparer<Type?>.Default.GetHashCode(QueryType);
+        public override int GetHashCode() => QueryType.GetHashCode();
 
         public override string ToString() => QueryType.ToString();
 
@@ -134,7 +134,7 @@ namespace ExRam.Gremlinq.Core
 
         public Type QueryType
         {
-            get => _queryType is { } semantics ? semantics : typeof(IGremlinQuery<object>);
+            get => _queryType ?? typeof(IGremlinQueryBase<object>);
         }
     }
 }

--- a/src/ExRam.Gremlinq.Core/Queries/Steps/CyclicPathStep.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/Steps/CyclicPathStep.cs
@@ -8,13 +8,4 @@
 
         public override Step OverrideQuerySemantics(QuerySemantics semantics) => new CyclicPathStep(semantics);
     }
-
-    public sealed class SimplePathStep : Step
-    {
-        public SimplePathStep(QuerySemantics? semantics = default) : base(semantics)
-        {
-        }
-
-        public override Step OverrideQuerySemantics(QuerySemantics semantics) => new SimplePathStep(semantics);
-    }
 }

--- a/src/ExRam.Gremlinq.Core/Queries/Steps/ProjectEdgeStep.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/Steps/ProjectEdgeStep.cs
@@ -1,0 +1,15 @@
+﻿namespace ExRam.Gremlinq.Core
+{
+    public sealed class ProjectEdgeStep : Step
+    {
+        public ProjectEdgeStep(QuerySemantics? semantics = null) : base(semantics)
+        {
+
+        }
+
+        public override Step OverrideQuerySemantics(QuerySemantics semantics)
+        {
+            return new ProjectEdgeStep(semantics);
+        }
+    }
+}

--- a/src/ExRam.Gremlinq.Core/Queries/Steps/ProjectVertexStep.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/Steps/ProjectVertexStep.cs
@@ -1,0 +1,15 @@
+﻿namespace ExRam.Gremlinq.Core
+{
+    public sealed class ProjectVertexStep : Step
+    {
+        public ProjectVertexStep(QuerySemantics? semantics = null) : base(semantics)
+        {
+
+        }
+
+        public override Step OverrideQuerySemantics(QuerySemantics semantics)
+        {
+            return new ProjectVertexStep(semantics);
+        }
+    }
+}

--- a/src/ExRam.Gremlinq.Core/Queries/Steps/SimplePathStep.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/Steps/SimplePathStep.cs
@@ -1,0 +1,11 @@
+﻿namespace ExRam.Gremlinq.Core
+{
+    public sealed class SimplePathStep : Step
+    {
+        public SimplePathStep(QuerySemantics? semantics = default) : base(semantics)
+        {
+        }
+
+        public override Step OverrideQuerySemantics(QuerySemantics semantics) => new SimplePathStep(semantics);
+    }
+}

--- a/src/ExRam.Gremlinq.Core/Serialization/GremlinQueryFragmentSerializer.cs
+++ b/src/ExRam.Gremlinq.Core/Serialization/GremlinQueryFragmentSerializer.cs
@@ -340,6 +340,10 @@ namespace ExRam.Gremlinq.Core
                     return CreateInstruction("by", recurse, env, traversal);
                 })
                 .Override<ProjectStep.ByKeyStep>((step, env, overridden, recurse) => CreateInstruction("by", recurse, env, step.Key))
+                .Override<ProjectVertexStep>((step, env, overridden, recurse) => env.Options.GetValue(env.FeatureSet.Supports(VertexFeatures.MetaProperties)
+                    ? GremlinqOption.VertexProjectionSteps
+                    : GremlinqOption.VertexProjectionWithoutMetaPropertiesSteps))
+                .Override<ProjectEdgeStep>((step, env, overridden, recurse) => env.Options.GetValue(GremlinqOption.EdgeProjectionSteps))
                 .Override<RangeStep>((step, env, overridden, recurse) => step.Scope.Equals(Scope.Local)
                     ? CreateInstruction("range", recurse, env, step.Scope, step.Lower, step.Upper)
                     : CreateInstruction("range", recurse, env, step.Lower, step.Upper))
@@ -388,10 +392,10 @@ namespace ExRam.Gremlinq.Core
                         }
                     }
 
-                    if (steps.Count == 0)
-                        steps = IdentitySteps;
-
                     Add(steps);
+
+                    if (byteCode.StepInstructions.Count == 0)
+                        Add(IdentityStep.Instance);
 
                     return byteCode;
                 })

--- a/test/ExRam.Gremlinq.Core.Tests/GremlinQueryFragmentSerializerTest.AllSteps.verified.txt
+++ b/test/ExRam.Gremlinq.Core.Tests/GremlinQueryFragmentSerializerTest.AllSteps.verified.txt
@@ -283,12 +283,6 @@
     }
   },
   {
-    Item1: SimplePathStep,
-    Item2: {
-      OperatorName: simplePath
-    }
-  },
-  {
     Item1: DedupStep,
     Item2: {
       OperatorName: dedup
@@ -797,6 +791,39 @@
     }
   },
   {
+    Item1: ProjectEdgeStep,
+    Item2: [
+      {
+        Projections: [
+          id,
+          label,
+          properties
+        ]
+      },
+      {
+        Key: {
+          RawKey: {
+            EnumName: T,
+            EnumValue: id
+          }
+        }
+      },
+      {
+        Key: {
+          RawKey: {
+            EnumName: T,
+            EnumValue: label
+          }
+        }
+      },
+      {
+        Traversal: [
+          {}
+        ]
+      }
+    ]
+  },
+  {
     Item1: ProjectStep,
     Item2: {
       OperatorName: project,
@@ -833,6 +860,90 @@
         }
       ]
     }
+  },
+  {
+    Item1: ProjectVertexStep,
+    Item2: [
+      {
+        Projections: [
+          id,
+          label,
+          properties
+        ]
+      },
+      {
+        Key: {
+          RawKey: {
+            EnumName: T,
+            EnumValue: id
+          }
+        }
+      },
+      {
+        Key: {
+          RawKey: {
+            EnumName: T,
+            EnumValue: label
+          }
+        }
+      },
+      {
+        Traversal: [
+          {},
+          {},
+          {
+            Key: {
+              RawKey: {
+                EnumName: T,
+                EnumValue: label
+              }
+            }
+          },
+          {
+            Traversal: [
+              {
+                Projections: [
+                  id,
+                  label,
+                  value,
+                  properties
+                ]
+              },
+              {
+                Key: {
+                  RawKey: {
+                    EnumName: T,
+                    EnumValue: id
+                  }
+                }
+              },
+              {
+                Key: {
+                  RawKey: {
+                    EnumName: T,
+                    EnumValue: label
+                  }
+                }
+              },
+              {
+                Key: {
+                  RawKey: {
+                    EnumName: T,
+                    EnumValue: value
+                  }
+                }
+              },
+              {
+                Traversal: [
+                  {}
+                ]
+              },
+              {}
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     Item1: PropertiesStep,
@@ -931,6 +1042,12 @@
           ]
         }
       ]
+    }
+  },
+  {
+    Item1: SimplePathStep,
+    Item2: {
+      OperatorName: simplePath
     }
   },
   {

--- a/test/ExRam.Gremlinq.Core.Tests/TypeSystemTest.All_Steps_can_be_created.verified.txt
+++ b/test/ExRam.Gremlinq.Core.Tests/TypeSystemTest.All_Steps_can_be_created.verified.txt
@@ -248,14 +248,6 @@
     }
   },
   {
-    Item1: SimplePathStep,
-    Item2: {
-      Semantics: {
-        QueryType: Object
-      }
-    }
-  },
-  {
     Item1: DedupStep,
     Item2: {
       Scope: {
@@ -797,6 +789,14 @@
     }
   },
   {
+    Item1: ProjectEdgeStep,
+    Item2: {
+      Semantics: {
+        QueryType: Object
+      }
+    }
+  },
+  {
     Item1: ProjectStep,
     Item2: {
       Projections: [
@@ -829,6 +829,14 @@
           EnumValue: id
         }
       },
+      Semantics: {
+        QueryType: Object
+      }
+    }
+  },
+  {
+    Item1: ProjectVertexStep,
+    Item2: {
       Semantics: {
         QueryType: Object
       }
@@ -954,6 +962,14 @@
       Traversal: [
         {}
       ],
+      Semantics: {
+        QueryType: Object
+      }
+    }
+  },
+  {
+    Item1: SimplePathStep,
+    Item2: {
       Semantics: {
         QueryType: Object
       }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -1541,6 +1541,11 @@
         public ProfileStep(ExRam.Gremlinq.Core.QuerySemantics? semantics = default) { }
         public override ExRam.Gremlinq.Core.Step OverrideQuerySemantics(ExRam.Gremlinq.Core.QuerySemantics semantics) { }
     }
+    public sealed class ProjectEdgeStep : ExRam.Gremlinq.Core.Step
+    {
+        public ProjectEdgeStep(ExRam.Gremlinq.Core.QuerySemantics? semantics = default) { }
+        public override ExRam.Gremlinq.Core.Step OverrideQuerySemantics(ExRam.Gremlinq.Core.QuerySemantics semantics) { }
+    }
     public sealed class ProjectStep : ExRam.Gremlinq.Core.Step
     {
         public ProjectStep(System.Collections.Immutable.ImmutableArray<string> projections, ExRam.Gremlinq.Core.QuerySemantics? semantics = default) { }
@@ -1562,6 +1567,11 @@
             public ExRam.Gremlinq.Core.Traversal Traversal { get; }
             public override ExRam.Gremlinq.Core.Step OverrideQuerySemantics(ExRam.Gremlinq.Core.QuerySemantics semantics) { }
         }
+    }
+    public sealed class ProjectVertexStep : ExRam.Gremlinq.Core.Step
+    {
+        public ProjectVertexStep(ExRam.Gremlinq.Core.QuerySemantics? semantics = default) { }
+        public override ExRam.Gremlinq.Core.Step OverrideQuerySemantics(ExRam.Gremlinq.Core.QuerySemantics semantics) { }
     }
     public sealed class PropertiesStep : ExRam.Gremlinq.Core.Step
     {


### PR DESCRIPTION
Only add ProjectEdgeSteps and ProjectVertexSteps to a Traversal, let serialization do the rest. Don't add the IdentityStep in ToTraversal.