### PR TITLE
Remove IWebSocketConfigurator.ConfigureGremlinClient.

### DIFF
--- a/src/ExRam.Gremlinq.Providers.WebSocket/Extensions/WebSocketConfiguratorExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.WebSocket/Extensions/WebSocketConfiguratorExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+using Gremlin.Net.Driver;
+
 namespace ExRam.Gremlinq.Providers.WebSocket
 {
     public static class WebSocketConfiguratorExtensions
@@ -12,6 +14,16 @@ namespace ExRam.Gremlinq.Providers.WebSocket
         public static IWebSocketConfigurator AtLocalhost(this IWebSocketConfigurator builder)
         {
             return builder.At(new Uri("ws://localhost:8182"));
+        }
+
+        public static IWebSocketConfigurator ConfigureGremlinClient(this IWebSocketConfigurator configurator, Func<IGremlinClient, IGremlinClient> transformation)
+        {
+            return configurator
+                .ConfigureGremlinClientFactory(factory => GremlinClientFactory
+                    .Create((server, serializer, poolSettings, optionsTransformation, sessionId) =>
+                    {
+                        return transformation(factory.Create(server, serializer, poolSettings, optionsTransformation, sessionId));
+                    }));
         }
     }
 }

--- a/src/ExRam.Gremlinq.Providers.WebSocket/IWebSocketConfigurator.cs
+++ b/src/ExRam.Gremlinq.Providers.WebSocket/IWebSocketConfigurator.cs
@@ -14,8 +14,6 @@ namespace ExRam.Gremlinq.Providers.WebSocket
 
         IWebSocketConfigurator ConfigureGremlinClientFactory(Func<IGremlinClientFactory, IGremlinClientFactory> transformation);
 
-        IWebSocketConfigurator ConfigureGremlinClient(Func<IGremlinClient, IGremlinClient> transformation);
-
         IWebSocketConfigurator ConfigureMessageSerializer(Func<IMessageSerializer, IMessageSerializer> transformation);
     }
 }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.WebSocket.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.WebSocket.verified.cs
@@ -33,7 +33,6 @@ namespace ExRam.Gremlinq.Providers.WebSocket
     {
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator At(System.Uri uri);
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator AuthenticateBy(string username, string password);
-        ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureGremlinClient(System.Func<Gremlin.Net.Driver.IGremlinClient, Gremlin.Net.Driver.IGremlinClient> transformation);
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureGremlinClientFactory(System.Func<ExRam.Gremlinq.Providers.WebSocket.IGremlinClientFactory, ExRam.Gremlinq.Providers.WebSocket.IGremlinClientFactory> transformation);
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureMessageSerializer(System.Func<Gremlin.Net.Driver.IMessageSerializer, Gremlin.Net.Driver.IMessageSerializer> transformation);
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator SetAlias(string alias);
@@ -47,6 +46,7 @@ namespace ExRam.Gremlinq.Providers.WebSocket
     {
         public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator At(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator builder, string uri) { }
         public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator AtLocalhost(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator builder) { }
+        public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureGremlinClient(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator configurator, System.Func<Gremlin.Net.Driver.IGremlinClient, Gremlin.Net.Driver.IGremlinClient> transformation) { }
     }
     public static class WebSocketGremlinqOptions
     {


### PR DESCRIPTION
 Its functionality can be easily restored with the help of ConfigureGremlinClientFactory, as the new ConfigureGremlinClient-extension in WebSocketConfiguratorExtensions.cs shows.