### PR TITLE
Remove IWebSocketConfigurator.ConfigureMessageSerializer.

### DIFF
--- a/src/ExRam.Gremlinq.Providers.WebSocket/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.WebSocket/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -152,33 +152,28 @@ namespace ExRam.Gremlinq.Core
         {
             private readonly Uri? _uri;
             private readonly string _alias;
-            private readonly IMessageSerializer _serializer;
             private readonly IGremlinClientFactory _clientFactory;
             private readonly (string username, string password)? _auth;
 
             public WebSocketConfigurator(
                 Uri? uri,
                 IGremlinClientFactory clientFactory,
-                IMessageSerializer serializer,
                 (string username, string password)? auth,
                 string alias)
             {
                 _uri = uri;
                 _auth = auth;
                 _alias = alias;
-                _serializer = serializer;
                 _clientFactory = clientFactory;
             }
 
-            public IWebSocketConfigurator At(Uri uri) => new WebSocketConfigurator(uri, _clientFactory, _serializer, _auth, _alias);
+            public IWebSocketConfigurator At(Uri uri) => new WebSocketConfigurator(uri, _clientFactory, _auth, _alias);
 
-            public IWebSocketConfigurator ConfigureGremlinClientFactory(Func<IGremlinClientFactory, IGremlinClientFactory> transformation) => new WebSocketConfigurator(_uri, transformation(_clientFactory), _serializer, _auth, _alias);
+            public IWebSocketConfigurator ConfigureGremlinClientFactory(Func<IGremlinClientFactory, IGremlinClientFactory> transformation) => new WebSocketConfigurator(_uri, transformation(_clientFactory), _auth, _alias);
 
-            public IWebSocketConfigurator ConfigureMessageSerializer(Func<IMessageSerializer, IMessageSerializer> transformation) => new WebSocketConfigurator(_uri, _clientFactory, transformation(_serializer), _auth, _alias);
+            public IWebSocketConfigurator AuthenticateBy(string username, string password) => new WebSocketConfigurator(_uri, _clientFactory, (username, password), _alias);
 
-            public IWebSocketConfigurator AuthenticateBy(string username, string password) => new WebSocketConfigurator(_uri, _clientFactory, _serializer, (username, password), _alias);
-
-            public IWebSocketConfigurator SetAlias(string alias) => new WebSocketConfigurator(_uri, _clientFactory, _serializer, _auth, alias);
+            public IWebSocketConfigurator SetAlias(string alias) => new WebSocketConfigurator(_uri, _clientFactory, _auth, alias);
 
             public IGremlinQuerySource Transform(IGremlinQuerySource source)
             {
@@ -204,7 +199,8 @@ namespace ExRam.Gremlinq.Core
                                 "wss".Equals(_uri.Scheme, StringComparison.OrdinalIgnoreCase),
                                 _auth?.username,
                                 _auth?.password),
-                            _serializer,
+                            JsonNetMessageSerializer.GraphSON3,
+                            null,
                             null,
                             null),
                         ct),
@@ -219,7 +215,6 @@ namespace ExRam.Gremlinq.Core
             var configurator = new WebSocketConfigurator(
                 default,
                 GremlinClientFactory.Default,
-                JsonNetMessageSerializer.GraphSON3,
                 null,
                 "g");
 

--- a/src/ExRam.Gremlinq.Providers.WebSocket/Extensions/WebSocketConfiguratorExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.WebSocket/Extensions/WebSocketConfiguratorExtensions.cs
@@ -25,5 +25,16 @@ namespace ExRam.Gremlinq.Providers.WebSocket
                         return transformation(factory.Create(server, serializer, poolSettings, optionsTransformation, sessionId));
                     }));
         }
+
+        public static IWebSocketConfigurator ConfigureMessageSerializer(this IWebSocketConfigurator configurator, Func<IMessageSerializer, IMessageSerializer> transformation)
+        {
+            return configurator
+                .ConfigureGremlinClientFactory(factory => GremlinClientFactory
+                    .Create((server, maybeSerializer, poolSettings, optionsTransformation, sessionId) =>
+                    {
+                        return factory.Create(server, maybeSerializer is { } serializer ? transformation(serializer) : maybeSerializer, poolSettings, optionsTransformation, sessionId);
+                    }));
+        }
+
     }
 }

--- a/src/ExRam.Gremlinq.Providers.WebSocket/IWebSocketConfigurator.cs
+++ b/src/ExRam.Gremlinq.Providers.WebSocket/IWebSocketConfigurator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using ExRam.Gremlinq.Core;
-using Gremlin.Net.Driver;
 
 namespace ExRam.Gremlinq.Providers.WebSocket
 {
@@ -13,7 +12,5 @@ namespace ExRam.Gremlinq.Providers.WebSocket
         IWebSocketConfigurator SetAlias(string alias);
 
         IWebSocketConfigurator ConfigureGremlinClientFactory(Func<IGremlinClientFactory, IGremlinClientFactory> transformation);
-
-        IWebSocketConfigurator ConfigureMessageSerializer(Func<IMessageSerializer, IMessageSerializer> transformation);
     }
 }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.WebSocket.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.WebSocket.verified.cs
@@ -34,7 +34,6 @@ namespace ExRam.Gremlinq.Providers.WebSocket
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator At(System.Uri uri);
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator AuthenticateBy(string username, string password);
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureGremlinClientFactory(System.Func<ExRam.Gremlinq.Providers.WebSocket.IGremlinClientFactory, ExRam.Gremlinq.Providers.WebSocket.IGremlinClientFactory> transformation);
-        ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureMessageSerializer(System.Func<Gremlin.Net.Driver.IMessageSerializer, Gremlin.Net.Driver.IMessageSerializer> transformation);
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator SetAlias(string alias);
     }
     public interface IWebSocketProviderConfigurator<out TConfigurator> : ExRam.Gremlinq.Core.IGremlinQuerySourceTransformation, ExRam.Gremlinq.Providers.Core.IProviderConfigurator<TConfigurator>
@@ -47,6 +46,7 @@ namespace ExRam.Gremlinq.Providers.WebSocket
         public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator At(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator builder, string uri) { }
         public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator AtLocalhost(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator builder) { }
         public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureGremlinClient(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator configurator, System.Func<Gremlin.Net.Driver.IGremlinClient, Gremlin.Net.Driver.IGremlinClient> transformation) { }
+        public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureMessageSerializer(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator configurator, System.Func<Gremlin.Net.Driver.IMessageSerializer, Gremlin.Net.Driver.IMessageSerializer> transformation) { }
     }
     public static class WebSocketGremlinqOptions
     {


### PR DESCRIPTION
Its functionality can be easily restored with the help of ConfigureGremlinClientFactory, as the new ConfigureMessageSerializer-extension in WebSocketConfiguratorExtensions.cs shows.