### PR TITLE
Introduce IWebSocketConfigurator.ConfigureGremlinServer.

### DIFF
--- a/src/ExRam.Gremlinq.Providers.WebSocket/Extensions/WebSocketConfiguratorExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.WebSocket/Extensions/WebSocketConfiguratorExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-
 using Gremlin.Net.Driver;
+using _GremlinServer = Gremlin.Net.Driver.GremlinServer;
 
 namespace ExRam.Gremlinq.Providers.WebSocket
 {
@@ -36,5 +36,24 @@ namespace ExRam.Gremlinq.Providers.WebSocket
                     }));
         }
 
+        public static IWebSocketConfigurator At(this IWebSocketConfigurator configurator, Uri uri)
+        {
+            if (!string.IsNullOrEmpty(uri.AbsolutePath) && uri.AbsolutePath != "/")
+                throw new ArgumentException($"The {nameof(Uri)} may not contain an {nameof(Uri.AbsolutePath)}.", nameof(uri));
+
+            return configurator.ConfigureGremlinServer(server => CreateGremlinServer(uri, server.Username, server.Password));
+        }
+
+        public static IWebSocketConfigurator AuthenticateBy(this IWebSocketConfigurator configurator, string username, string password) => configurator.ConfigureGremlinServer(server => CreateGremlinServer(server.Uri, username, password));
+
+        private static _GremlinServer CreateGremlinServer(Uri uri, string username, string password)
+        {
+            return new _GremlinServer(
+                uri.Host,
+                uri.Port,
+                "wss".Equals(uri.Scheme, StringComparison.OrdinalIgnoreCase),
+                username,
+                password);
+        }
     }
 }

--- a/src/ExRam.Gremlinq.Providers.WebSocket/IWebSocketConfigurator.cs
+++ b/src/ExRam.Gremlinq.Providers.WebSocket/IWebSocketConfigurator.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using ExRam.Gremlinq.Core;
+using _GremlinServer = Gremlin.Net.Driver.GremlinServer;
 
 namespace ExRam.Gremlinq.Providers.WebSocket
 {
     public interface IWebSocketConfigurator : IGremlinQuerySourceTransformation
     {
-        IWebSocketConfigurator At(Uri uri);
-
-        IWebSocketConfigurator AuthenticateBy(string username, string password);
-
         IWebSocketConfigurator SetAlias(string alias);
+
+        IWebSocketConfigurator ConfigureGremlinServer(Func<_GremlinServer, _GremlinServer> transformation);
 
         IWebSocketConfigurator ConfigureGremlinClientFactory(Func<IGremlinClientFactory, IGremlinClientFactory> transformation);
     }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.WebSocket.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.WebSocket.verified.cs
@@ -31,9 +31,8 @@ namespace ExRam.Gremlinq.Providers.WebSocket
     }
     public interface IWebSocketConfigurator : ExRam.Gremlinq.Core.IGremlinQuerySourceTransformation
     {
-        ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator At(System.Uri uri);
-        ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator AuthenticateBy(string username, string password);
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureGremlinClientFactory(System.Func<ExRam.Gremlinq.Providers.WebSocket.IGremlinClientFactory, ExRam.Gremlinq.Providers.WebSocket.IGremlinClientFactory> transformation);
+        ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureGremlinServer(System.Func<Gremlin.Net.Driver.GremlinServer, Gremlin.Net.Driver.GremlinServer> transformation);
         ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator SetAlias(string alias);
     }
     public interface IWebSocketProviderConfigurator<out TConfigurator> : ExRam.Gremlinq.Core.IGremlinQuerySourceTransformation, ExRam.Gremlinq.Providers.Core.IProviderConfigurator<TConfigurator>
@@ -44,7 +43,9 @@ namespace ExRam.Gremlinq.Providers.WebSocket
     public static class WebSocketConfiguratorExtensions
     {
         public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator At(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator builder, string uri) { }
+        public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator At(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator configurator, System.Uri uri) { }
         public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator AtLocalhost(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator builder) { }
+        public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator AuthenticateBy(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator configurator, string username, string password) { }
         public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureGremlinClient(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator configurator, System.Func<Gremlin.Net.Driver.IGremlinClient, Gremlin.Net.Driver.IGremlinClient> transformation) { }
         public static ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator ConfigureMessageSerializer(this ExRam.Gremlinq.Providers.WebSocket.IWebSocketConfigurator configurator, System.Func<Gremlin.Net.Driver.IMessageSerializer, Gremlin.Net.Driver.IMessageSerializer> transformation) { }
     }


### PR DESCRIPTION
This allows the removal of IWebSocketConfigurator.AuthenticateBy and IWebSocketConfigurator.At, which are easily recreated by ConfigureGremlinServer as the new extensions show.