### PR TITLE
Always output a complex structure in Debug, even when there are no bindings

### DIFF
--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.cs
@@ -601,17 +601,13 @@ namespace ExRam.Gremlinq.Core
                 .Serialize(this)
                 .ToGroovy(groovyFormatting);
 
-            return groovy.Bindings.Count > 0
-                ? JsonConvert.SerializeObject(
-                    new
-                    {
-                        groovy.Script,
-                        groovy.Bindings
-                    },
-                    indented
-                        ? Formatting.Indented
-                        : Formatting.None)
-                : groovy.Script;
+            return JsonConvert.SerializeObject(
+                groovy.Bindings.Count > 0
+                    ? new { groovy.Script, groovy.Bindings }
+                    : new { groovy.Script },
+                indented
+                    ? Formatting.Indented
+                    : Formatting.None);
         }
 
         private GremlinQuery<TElement, TOutVertex, TInVertex, TScalar, TMeta, TFoldedQuery> DedupGlobal() => AddStep(DedupStep.Global);

--- a/test/ExRam.Gremlinq.Core.Tests/GremlinQueryTest.Debug.verified.txt
+++ b/test/ExRam.Gremlinq.Core.Tests/GremlinQueryTest.Debug.verified.txt
@@ -1,1 +1,1 @@
-﻿g.V().hasLabel('Person').has('Age',gt(36)).out('LivesIn').hasLabel('Country').project('id','label','properties').by(id).by(label).by(__.properties().group().by(label).by(__.project('id','label','value','properties').by(id).by(label).by(value).by(__.valueMap()).fold()))
+﻿{"Script":"g.V().hasLabel('Person').has('Age',gt(36)).out('LivesIn').hasLabel('Country').project('id','label','properties').by(id).by(label).by(__.properties().group().by(label).by(__.project('id','label','value','properties').by(id).by(label).by(value).by(__.valueMap()).fold()))"}


### PR DESCRIPTION
This reverts an earlier change, but it's more consistent this way.