### PR TITLE
Add an overload for V that takes a single id.

### DIFF
--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
@@ -280,6 +280,8 @@ namespace ExRam.Gremlinq.Core
 
         IValueGremlinQuery<TNewElement> IStartGremlinQuery.Inject<TNewElement>(params TNewElement[] elements) => Inject(elements);
 
+        IVertexGremlinQuery<object> IStartGremlinQuery.V(object id) => AddStepWithObjectTypes<object>(new VStep(ImmutableArray.Create(id)), _ => Projection.Vertex);
+
         IVertexGremlinQuery<object> IStartGremlinQuery.V(params object[] ids) => AddStepWithObjectTypes<object>(new VStep(ids.ToImmutableArray()), _ => Projection.Vertex);
 
         IVertexGremlinQuery<TNewVertex> IStartGremlinQuery.ReplaceV<TNewVertex>(TNewVertex vertex) => ((IStartGremlinQuery)this).V<TNewVertex>(vertex!.GetId(Environment)).Update(vertex);

--- a/src/ExRam.Gremlinq.Core/Queries/Interfaces/IStartGremlinQuery.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/Interfaces/IStartGremlinQuery.cs
@@ -10,6 +10,7 @@
 
         IGremlinQueryAdmin AsAdmin();
 
+        IVertexGremlinQuery<object> V(object id);
         IVertexGremlinQuery<object> V(params object[] ids);
         IVertexGremlinQuery<TVertex> V<TVertex>(params object[] ids);
 

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -762,6 +762,7 @@
         ExRam.Gremlinq.Core.IGremlinQueryAdmin AsAdmin();
         ExRam.Gremlinq.Core.IValueGremlinQuery<TElement> Inject<TElement>(params TElement[] elements);
         ExRam.Gremlinq.Core.IVertexGremlinQuery<TNewVertex> ReplaceV<TNewVertex>(TNewVertex vertex);
+        ExRam.Gremlinq.Core.IVertexGremlinQuery<object> V(object id);
         ExRam.Gremlinq.Core.IVertexGremlinQuery<object> V(params object[] ids);
         ExRam.Gremlinq.Core.IVertexGremlinQuery<TVertex> V<TVertex>(params object[] ids);
     }


### PR DESCRIPTION
 It'll save an array allocation in most cases.