### PR TITLE
Remove mixed equality and inequality operators on StepLabel.

### DIFF
--- a/src/ExRam.Gremlinq.Core/Queries/StepLabel.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/StepLabel.cs
@@ -54,20 +54,9 @@ namespace ExRam.Gremlinq.Core
         {
         }
 
+        public TElement Value => ThrowConversion();
+
         public static implicit operator StepLabel<TElement>(string str) => new(str);
-
-        public static bool operator ==(TElement? a, StepLabel<TElement>? b) => ThrowEquality();
-
-        public static bool operator !=(TElement? a, StepLabel<TElement>? b) => ThrowEquality();
-
-        public static bool operator ==(StepLabel<TElement>? b, TElement? a) => ThrowEquality();
-
-        public static bool operator !=(StepLabel<TElement>? b, TElement? a) => ThrowEquality();
-
-        public TElement Value
-        {
-            get => ThrowConversion();
-        }
 
         private static bool ThrowEquality() => throw new NotImplementedException($"The equality/inequality operators on {nameof(StepLabel)} are not intended to be called. Their use is to appear in expressions only.");
 

--- a/test/ExRam.Gremlinq.Core.Tests/QueryExecutionTest.cs
+++ b/test/ExRam.Gremlinq.Core.Tests/QueryExecutionTest.cs
@@ -2860,7 +2860,7 @@ namespace ExRam.Gremlinq.Core.Tests
                     .V<Company>()
                     .Properties(x => x.Locations!)
                     .Properties()
-                    .Where(x => x.Key == stepLabel))
+                    .Where(x => x.Key == stepLabel.Value))
                 .Verify();
         }
 
@@ -3039,7 +3039,7 @@ namespace ExRam.Gremlinq.Core.Tests
                 .As((__, l) => __
                     .V<Country>()
                     .Properties(x => x.Languages!)
-                    .Where(x => x.Label == l))
+                    .Where(x => x.Label == l.Value))
                 .Verify();
         }
 
@@ -4576,7 +4576,7 @@ namespace ExRam.Gremlinq.Core.Tests
                 .V<Language>()
                 .As((__, l) => __
                     .V<Language>()
-                    .Where(l2 => l2 == l))
+                    .Where(l2 => l2 == l.Value))
                 .Verify();
         }
 
@@ -4587,7 +4587,7 @@ namespace ExRam.Gremlinq.Core.Tests
                 .V<Language>()
                 .As((__, l) => __
                     .V<Language>()
-                    .Where(l2 => l == l2))
+                    .Where(l2 => l.Value == l2))
                 .Verify();
         }
 
@@ -4598,7 +4598,7 @@ namespace ExRam.Gremlinq.Core.Tests
                 .V<Language>()
                 .As((__, l) => __
                     .V<Language>()
-                    .Where(l2 => l2 != l))
+                    .Where(l2 => l2 != l.Value))
                 .Verify();
         }
 
@@ -4609,7 +4609,7 @@ namespace ExRam.Gremlinq.Core.Tests
                 .V<Language>()
                 .As((__, l) => __
                     .V<Language>()
-                    .Where(l2 => l != l2))
+                    .Where(l2 => l.Value != l2))
                 .Verify();
         }
 
@@ -5096,7 +5096,7 @@ namespace ExRam.Gremlinq.Core.Tests
                 .Values(x => x.IetfLanguageTag)
                 .As((__, l) => __
                     .V<Language>()
-                    .Where(l2 => l2.IetfLanguageTag == l))
+                    .Where(l2 => l2.IetfLanguageTag == l.Value))
                 .Verify();
         }
 

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -945,10 +945,6 @@
         public StepLabel() { }
         public TElement Value { get; }
         public new static ExRam.Gremlinq.Core.StepLabel<TElement> op_Implicit(string str) { }
-        public static bool operator !=(ExRam.Gremlinq.Core.StepLabel<TElement>? b, TElement? a) { }
-        public static bool operator !=(TElement? a, ExRam.Gremlinq.Core.StepLabel<TElement>? b) { }
-        public static bool operator ==(ExRam.Gremlinq.Core.StepLabel<TElement>? b, TElement? a) { }
-        public static bool operator ==(TElement? a, ExRam.Gremlinq.Core.StepLabel<TElement>? b) { }
     }
     public class StepLabel<TQuery, TElement> : ExRam.Gremlinq.Core.StepLabel<TElement>
         where TQuery : ExRam.Gremlinq.Core.IGremlinQueryBase


### PR DESCRIPTION
First, the list of operators is not exhaustive, seconds, it's advised to use the Value property which lowers equality on TElement. That's enough for expressions.