### PR TITLE
Exposes request id to developers.

### DIFF
--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.Helpers.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.Helpers.cs
@@ -56,7 +56,7 @@ namespace ExRam.Gremlinq.Core
 
         private ContinuationBuilder<GremlinQuery<TElement, TOutVertex, TInVertex, TScalar, TMeta, TFoldedQuery>, GremlinQuery<TElement, TOutVertex, TInVertex, TScalar, TMeta, TFoldedQuery>> Continue(ContinuationFlags flags = ContinuationFlags.None) => new(
             this,
-            new GremlinQuery<TElement, TOutVertex, TInVertex, TScalar, TMeta, TFoldedQuery>(Environment, Traversal.Empty.WithProjection(Steps.Projection), LabelProjections, QueryFlags.IsAnonymous), flags);
+            new GremlinQuery<TElement, TOutVertex, TInVertex, TScalar, TMeta, TFoldedQuery>(Environment, Traversal.Empty.WithProjection(Steps.Projection), LabelProjections, QueryFlags.IsAnonymous, RequestIdSource), flags);
 
         private Key GetKey(Expression projection) => Environment.GetKey(projection);
 

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
@@ -311,7 +311,7 @@ namespace ExRam.Gremlinq.Core
 
         IEdgeGremlinQuery<TNewEdge> IStartGremlinQuery.ReplaceE<TNewEdge>(TNewEdge edge) => ((IGremlinQuerySource)this).E<TNewEdge>(edge!.GetId(Environment)).Update(edge);
 
-        IGremlinQuerySource IConfigurableGremlinQuerySource.ConfigureEnvironment(Func<IGremlinQueryEnvironment, IGremlinQueryEnvironment> transformation) => new GremlinQuery<TElement, TOutVertex, TInVertex, TScalar, TMeta, TFoldedQuery>(transformation(Environment), Steps, LabelProjections, Flags);
+        IGremlinQuerySource IConfigurableGremlinQuerySource.ConfigureEnvironment(Func<IGremlinQueryEnvironment, IGremlinQueryEnvironment> transformation) => new GremlinQuery<TElement, TOutVertex, TInVertex, TScalar, TMeta, TFoldedQuery>(transformation(Environment), Steps, LabelProjections, Flags, RequestIdSource);
 
         IGremlinQuerySource IGremlinQuerySource.WithoutStrategies(params Type[] strategyTypes) => WithoutStrategies(strategyTypes);
 
@@ -363,6 +363,7 @@ namespace ExRam.Gremlinq.Core
 
         IInOrOutEdgeGremlinQuery<TEdge, TElement> IVertexGremlinQueryBase<TElement>.AddE<TEdge>() => AddE(new TEdge());
 
+        RequestIdSource IGremlinQueryBase.RequestIdSource { get => RequestIdSource; set => RequestIdSource = value; }
         IVertexGremlinQuery<object> IVertexGremlinQueryBase.Both() => Both();
 
         IVertexGremlinQuery<object> IVertexGremlinQueryBase.Both<TEdge>() => Both<TEdge>();

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQueryBase.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQueryBase.cs
@@ -19,12 +19,14 @@ namespace ExRam.Gremlinq.Core
             IGremlinQueryEnvironment environment,
             Traversal steps,
             IImmutableDictionary<StepLabel, LabelProjections> labelProjections,
-            QueryFlags flags)
+            QueryFlags flags,
+            RequestIdSource requestIdSource)
         {
             Steps = steps;
             Flags = flags;
             Environment = environment;
             LabelProjections = labelProjections;
+            RequestIdSource = requestIdSource;
         }
 
         public override string ToString() => $"GremlinQuery(Steps.Count: {Steps.Count})";
@@ -91,7 +93,8 @@ namespace ExRam.Gremlinq.Core
                     existingQuery.Environment,
                     newTraversal,
                     newLabelProjections,
-                    newQueryFlags);
+                    newQueryFlags,
+                    existingQuery.RequestIdSource);
             };
         }
 
@@ -119,5 +122,6 @@ namespace ExRam.Gremlinq.Core
         protected internal QueryFlags Flags { get; }
         protected internal IGremlinQueryEnvironment Environment { get; }
         protected internal IImmutableDictionary<StepLabel, LabelProjections> LabelProjections { get; }
+        protected internal RequestIdSource RequestIdSource { get; set; }
     }
 }

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuerySource.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuerySource.cs
@@ -9,6 +9,7 @@ namespace ExRam.Gremlinq.Core
             GremlinQueryEnvironment.Default,
             Traversal.Empty,
             ImmutableDictionary<StepLabel, LabelProjections>.Empty,
-            QueryFlags.None);
+            QueryFlags.None,
+            RequestIdSource.Default);
     }
 }

--- a/src/ExRam.Gremlinq.Core/Queries/Interfaces/IGremlinQuery.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/Interfaces/IGremlinQuery.cs
@@ -7,6 +7,9 @@ namespace ExRam.Gremlinq.Core
 {
     public interface IGremlinQueryBase : IStartGremlinQuery
     {
+        internal RequestIdSource RequestIdSource { get; set; }
+        public Guid RequestId => RequestIdSource.RequestId;
+
         TaskAwaiter GetAwaiter();
 
         IGremlinQuery<TResult> Cast<TResult>();

--- a/src/ExRam.Gremlinq.Core/Queries/RequestIdSource.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/RequestIdSource.cs
@@ -1,0 +1,15 @@
+﻿namespace ExRam.Gremlinq.Core
+{
+    internal class RequestIdSource
+    {
+        internal static readonly RequestIdSource Default = new RequestIdSource(nameof(Default));
+
+        internal RequestIdSource(string name = "unspecified")
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+        internal Guid RequestId { get; set; }
+    }
+}

--- a/src/ExRam.Gremlinq.Core/Serialization/GremlinQuerySerializer.cs
+++ b/src/ExRam.Gremlinq.Core/Serialization/GremlinQuerySerializer.cs
@@ -50,7 +50,10 @@
                     .Serialize(query, query.AsAdmin().Environment) ?? throw new ArgumentException($"{nameof(query)} did not serialize to a non-null value.");
 
                 if (serialized is ISerializedGremlinQuery serializedQuery)
+                {
+                    query.RequestIdSource.RequestId = Guid.Parse(serializedQuery.Id); //assigns the request id to the RequestIdSource
                     return serializedQuery;
+                }
 
                 throw new InvalidOperationException($"Unable to serialize a query of type {query.GetType().FullName}.");
             }


### PR DESCRIPTION
Exposes the request id using a class as reference container (RequestIdSource).

The request id is important for identifying request uniqueness. For example: correlating an individual gremlinq call to a particular set of data.