### PR TITLE
In a move away from Newtonsoft.Json, we introduce our own QueryLogFormatting enum.

### DIFF
--- a/src/ExRam.Gremlinq.Core.AspNet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ExRam.Gremlinq.Core.AspNet/Extensions/ServiceCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using ExRam.Gremlinq.Core.AspNet;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using static ExRam.Gremlinq.Core.GremlinQuerySource;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -43,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
                                         if (Enum.TryParse<LogLevel>(loggingSection[$"{nameof(LogLevel)}"], out var logLevel))
                                             options = options.SetValue(GremlinqOption.QueryLogLogLevel, logLevel);
 
-                                        if (Enum.TryParse<Formatting>(loggingSection[$"{nameof(Formatting)}"], out var formatting))
+                                        if (Enum.TryParse<QueryLogFormatting>(loggingSection["Formatting"], out var formatting))
                                             options = options.SetValue(GremlinqOption.QueryLogFormatting, formatting);
 
                                         return options;

--- a/src/ExRam.Gremlinq.Core/Extensions/GremlinQueryExecutorExtensions.cs
+++ b/src/ExRam.Gremlinq.Core/Extensions/GremlinQueryExecutorExtensions.cs
@@ -141,7 +141,7 @@ namespace ExRam.Gremlinq.Core.Execution
                                         ? groovyQuery.Bindings
                                         : null
                                 },
-                                formatting));
+                                (Formatting)(int)formatting));
                     }
                 };
             }

--- a/src/ExRam.Gremlinq.Core/Options/GremlinqOption.cs
+++ b/src/ExRam.Gremlinq.Core/Options/GremlinqOption.cs
@@ -4,7 +4,6 @@ using ExRam.Gremlinq.Core.Projections;
 using ExRam.Gremlinq.Core.Steps;
 using Gremlin.Net.Process.Traversal;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace ExRam.Gremlinq.Core
 {
@@ -89,7 +88,7 @@ namespace ExRam.Gremlinq.Core
         public static readonly GremlinqOption<StringComparisonTranslationStrictness> StringComparisonTranslationStrictness = new(Core.StringComparisonTranslationStrictness.Strict);
 
         public static readonly GremlinqOption<LogLevel> QueryLogLogLevel = new(LogLevel.Debug);
-        public static readonly GremlinqOption<Formatting> QueryLogFormatting = new(Formatting.None);
+        public static readonly GremlinqOption<QueryLogFormatting> QueryLogFormatting = new(Core.QueryLogFormatting.None);
         public static readonly GremlinqOption<QueryLogVerbosity> QueryLogVerbosity = new(Core.QueryLogVerbosity.QueryOnly);
     }
 

--- a/src/ExRam.Gremlinq.Core/Options/QueryLogFormatting.cs
+++ b/src/ExRam.Gremlinq.Core/Options/QueryLogFormatting.cs
@@ -1,0 +1,9 @@
+﻿namespace ExRam.Gremlinq.Core
+{
+    [Flags]
+    public enum QueryLogFormatting
+    {
+        None = 0,
+        Indented = 1
+    }
+}

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -200,7 +200,7 @@ namespace ExRam.Gremlinq.Core
         public static readonly ExRam.Gremlinq.Core.GremlinqOption<ExRam.Gremlinq.Core.Traversal> EmptyProjectionProtectionDecoratorSteps;
         public static readonly ExRam.Gremlinq.Core.GremlinqOption<bool> EnableEmptyProjectionValueProtection;
         public static readonly ExRam.Gremlinq.Core.GremlinqOption<ExRam.Gremlinq.Core.FilterLabelsVerbosity> FilterLabelsVerbosity;
-        public static readonly ExRam.Gremlinq.Core.GremlinqOption<Newtonsoft.Json.Formatting> QueryLogFormatting;
+        public static readonly ExRam.Gremlinq.Core.GremlinqOption<ExRam.Gremlinq.Core.QueryLogFormatting> QueryLogFormatting;
         public static readonly ExRam.Gremlinq.Core.GremlinqOption<Microsoft.Extensions.Logging.LogLevel> QueryLogLogLevel;
         public static readonly ExRam.Gremlinq.Core.GremlinqOption<ExRam.Gremlinq.Core.QueryLogVerbosity> QueryLogVerbosity;
         public static readonly ExRam.Gremlinq.Core.GremlinqOption<System.Func<ExRam.Gremlinq.Core.StepLabel, ExRam.Gremlinq.Core.Projections.Projection>> StepLabelProjectionFallback;
@@ -1070,6 +1070,12 @@ namespace ExRam.Gremlinq.Core
         public bool Equals(ExRam.Gremlinq.Core.LabelProjections other) { }
         public ExRam.Gremlinq.Core.LabelProjections WithSideEffectLabelProjection(ExRam.Gremlinq.Core.Projections.Projection sideEffectLabelProjection) { }
         public ExRam.Gremlinq.Core.LabelProjections WithStepLabelProjection(ExRam.Gremlinq.Core.Projections.Projection stepLabelProjection) { }
+    }
+    [System.Flags]
+    public enum QueryLogFormatting
+    {
+        None = 0,
+        Indented = 1,
     }
     [System.Flags]
     public enum QueryLogVerbosity

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "11.1.0-preview.{height}",
+  "version": "12.0.0-preview.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
 This is a breaking change.