### PR TITLE
Rework notion of native types

### DIFF
--- a/src/ExRam.Gremlinq.Core/Cache/GremlinQueryEnvironmentCache.cs
+++ b/src/ExRam.Gremlinq.Core/Cache/GremlinQueryEnvironmentCache.cs
@@ -80,7 +80,7 @@ namespace ExRam.Gremlinq.Core
                             .ToArray(),
                         StringComparer.OrdinalIgnoreCase);
 
-                FastNativeTypes = environment.Model.NativeTypes
+                FastNativeTypes = environment.NativeTypes
                     .ToDictionary(static x => x, static _ => default(object?));
 
                 _keyLookup = new KeyLookup(_environment.Model.PropertiesModel);

--- a/src/ExRam.Gremlinq.Core/Environment/GremlinQueryEnvironment.cs
+++ b/src/ExRam.Gremlinq.Core/Environment/GremlinQueryEnvironment.cs
@@ -161,6 +161,8 @@ namespace ExRam.Gremlinq.Core
         public static IGremlinQueryEnvironment StoreByteArraysAsBase64String(this IGremlinQueryEnvironment environment)
         {
             return environment
+                .ConfigureNativeTypes(nativeTypes => nativeTypes
+                    .Remove(typeof(byte[])))
                 .ConfigureSerializer(static _ => _
                     .Add(Create<byte[], string>(static (bytes, env, recurse) => recurse
                         .TransformTo<string>()

--- a/src/ExRam.Gremlinq.Core/Environment/GremlinQueryEnvironment.cs
+++ b/src/ExRam.Gremlinq.Core/Environment/GremlinQueryEnvironment.cs
@@ -147,17 +147,6 @@ namespace ExRam.Gremlinq.Core
 
         public static IGremlinQueryEnvironment UseGraphSon3(this IGremlinQueryEnvironment environment) => environment.UseGraphSon(new GraphSON3Writer(), "application/vnd.gremlin-v3.0+json");
 
-        public static IGremlinQueryEnvironment StoreTimeSpansAsNumbers(this IGremlinQueryEnvironment environment)
-        {
-            return environment
-                .ConfigureSerializer(static serializer => serializer
-                    .Add(ConverterFactory
-                        .Create<TimeSpan, double>(static (t, _, _) => t.TotalMilliseconds)
-                        .AutoRecurse<double>()))
-                .ConfigureDeserializer(static deserializer => deserializer
-                    .Add(new TimeSpanAsNumberConverterFactory()));
-        }
-
         private static IGremlinQueryEnvironment UseGraphSon(this IGremlinQueryEnvironment environment, GraphSONWriter writer, string mimeType)
         {
             var mimeTypeBytes = Encoding.UTF8.GetBytes($"{(char)mimeType.Length}{mimeType}");

--- a/src/ExRam.Gremlinq.Core/Environment/GremlinQueryEnvironment.cs
+++ b/src/ExRam.Gremlinq.Core/Environment/GremlinQueryEnvironment.cs
@@ -158,17 +158,6 @@ namespace ExRam.Gremlinq.Core
                     .Add(new TimeSpanAsNumberConverterFactory()));
         }
 
-        public static IGremlinQueryEnvironment StoreByteArraysAsBase64String(this IGremlinQueryEnvironment environment)
-        {
-            return environment
-                .ConfigureNativeTypes(nativeTypes => nativeTypes
-                    .Remove(typeof(byte[])))
-                .ConfigureSerializer(static _ => _
-                    .Add(Create<byte[], string>(static (bytes, env, recurse) => recurse
-                        .TransformTo<string>()
-                        .From(Convert.ToBase64String(bytes), env))));
-        }
-
         private static IGremlinQueryEnvironment UseGraphSon(this IGremlinQueryEnvironment environment, GraphSONWriter writer, string mimeType)
         {
             var mimeTypeBytes = Encoding.UTF8.GetBytes($"{(char)mimeType.Length}{mimeType}");

--- a/src/ExRam.Gremlinq.Core/Environment/IGremlinQueryEnvironment.cs
+++ b/src/ExRam.Gremlinq.Core/Environment/IGremlinQueryEnvironment.cs
@@ -1,4 +1,5 @@
-﻿using ExRam.Gremlinq.Core.Execution;
+﻿using System.Collections.Immutable;
+using ExRam.Gremlinq.Core.Execution;
 using ExRam.Gremlinq.Core.Models;
 using ExRam.Gremlinq.Core.Transformation;
 using Microsoft.Extensions.Logging;
@@ -13,6 +14,7 @@ namespace ExRam.Gremlinq.Core
         IGremlinQueryEnvironment ConfigureSerializer(Func<ITransformer, ITransformer> serializerTransformation);
         IGremlinQueryEnvironment ConfigureOptions(Func<IGremlinqOptions, IGremlinqOptions> optionsTransformation);
         IGremlinQueryEnvironment ConfigureDeserializer(Func<ITransformer, ITransformer> deserializerTransformation);
+        IGremlinQueryEnvironment ConfigureNativeTypes(Func<IImmutableSet<Type>, IImmutableSet<Type>> transformation);
         IGremlinQueryEnvironment ConfigureDebugger(Func<IGremlinQueryDebugger, IGremlinQueryDebugger> debuggerTransformation);
         IGremlinQueryEnvironment ConfigureExecutor(Func<IGremlinQueryExecutor, IGremlinQueryExecutor> executorTransformation);
 
@@ -25,5 +27,6 @@ namespace ExRam.Gremlinq.Core
         ITransformer Deserializer { get; }
         IGremlinQueryDebugger Debugger { get; }
         IGremlinQueryExecutor Executor { get; }
+        IImmutableSet<Type> NativeTypes { get; }
     }
 }

--- a/src/ExRam.Gremlinq.Core/ExpressionParsing/ExpressionFragment.cs
+++ b/src/ExRam.Gremlinq.Core/ExpressionParsing/ExpressionFragment.cs
@@ -50,7 +50,7 @@ namespace ExRam.Gremlinq.Core.ExpressionParsing
                     ? StepLabel(stepLabel!, stepLabelExpression)
                     : Constant(expression.GetValue() switch
                     {
-                        IEnumerable enumerable when enumerable is not ICollection && !environment.GetCache().FastNativeTypes.ContainsKey(enumerable.GetType()) => enumerable.Cast<object>().ToArray(),
+                        IEnumerable enumerable when enumerable is not ICollection && !environment.SupportsType(enumerable.GetType()) => enumerable.Cast<object>().ToArray(),
                         { } val => val,
                         _ => null
                     });

--- a/src/ExRam.Gremlinq.Core/ExpressionParsing/ExpressionFragment.cs
+++ b/src/ExRam.Gremlinq.Core/ExpressionParsing/ExpressionFragment.cs
@@ -50,7 +50,7 @@ namespace ExRam.Gremlinq.Core.ExpressionParsing
                     ? StepLabel(stepLabel!, stepLabelExpression)
                     : Constant(expression.GetValue() switch
                     {
-                        IEnumerable enumerable when enumerable is not ICollection && !environment.NativeTypes.Contains(enumerable.GetType()) => enumerable.Cast<object>().ToArray(),
+                        IEnumerable enumerable when enumerable is not ICollection && !environment.GetCache().FastNativeTypes.ContainsKey(enumerable.GetType()) => enumerable.Cast<object>().ToArray(),
                         { } val => val,
                         _ => null
                     });

--- a/src/ExRam.Gremlinq.Core/ExpressionParsing/ExpressionFragment.cs
+++ b/src/ExRam.Gremlinq.Core/ExpressionParsing/ExpressionFragment.cs
@@ -40,7 +40,7 @@ namespace ExRam.Gremlinq.Core.ExpressionParsing
 
         public ExpressionFragmentType Type { get; }
 
-        public static ExpressionFragment Create(Expression expression, IGraphModel model)
+        public static ExpressionFragment Create(Expression expression, IGremlinQueryEnvironment environment)
         {
             expression = expression.StripConvert();
 
@@ -50,7 +50,7 @@ namespace ExRam.Gremlinq.Core.ExpressionParsing
                     ? StepLabel(stepLabel!, stepLabelExpression)
                     : Constant(expression.GetValue() switch
                     {
-                        IEnumerable enumerable when enumerable is not ICollection && !model.NativeTypes.Contains(enumerable.GetType()) => enumerable.Cast<object>().ToArray(),
+                        IEnumerable enumerable when enumerable is not ICollection && !environment.NativeTypes.Contains(enumerable.GetType()) => enumerable.Cast<object>().ToArray(),
                         { } val => val,
                         _ => null
                     });

--- a/src/ExRam.Gremlinq.Core/Extensions/GremlinQueryEnvironmentExtensions.cs
+++ b/src/ExRam.Gremlinq.Core/Extensions/GremlinQueryEnvironmentExtensions.cs
@@ -1,0 +1,24 @@
+﻿namespace ExRam.Gremlinq.Core
+{
+    public static class GremlinQueryEnvironmentExtensions
+    {
+        public static bool SupportsType(this IGremlinQueryEnvironment environment, Type type)
+        {
+            if (environment.SupportsTypeNatively(type))
+                return true;
+
+            if (type == typeof(byte))
+                return environment.SupportsTypeNatively(typeof(string));
+
+            if (type == typeof(TimeSpan))
+                return environment.SupportsTypeNatively(typeof(double));
+
+            return false;
+        }
+
+        public static bool SupportsTypeNatively(this IGremlinQueryEnvironment environment, Type type)
+        {
+            return environment.GetCache().FastNativeTypes.ContainsKey(type);
+        }
+    }
+}

--- a/src/ExRam.Gremlinq.Core/Extensions/GremlinQueryEnvironmentExtensions.cs
+++ b/src/ExRam.Gremlinq.Core/Extensions/GremlinQueryEnvironmentExtensions.cs
@@ -7,7 +7,7 @@
             if (environment.SupportsTypeNatively(type))
                 return true;
 
-            if (type == typeof(byte))
+            if (type == typeof(byte[]))
                 return environment.SupportsTypeNatively(typeof(string));
 
             if (type == typeof(TimeSpan))

--- a/src/ExRam.Gremlinq.Core/Models/GraphModel.cs
+++ b/src/ExRam.Gremlinq.Core/Models/GraphModel.cs
@@ -7,49 +7,11 @@ namespace ExRam.Gremlinq.Core.Models
     {
         private sealed class GraphModelImpl : IGraphModel
         {
-            private static readonly IImmutableSet<Type> DefaultNativeTypes = new[]
-            {
-                typeof(bool),
-                typeof(byte),
-                typeof(byte[]),
-                typeof(sbyte),
-                typeof(short),
-                typeof(ushort),
-                typeof(int),
-                typeof(uint),
-                typeof(long),
-                typeof(ulong),
-                typeof(float),
-                typeof(double),
-                typeof(string),
-                typeof(Guid),
-                typeof(TimeSpan),
-                typeof(DateTime),
-                typeof(DateTimeOffset)
-            }.ToImmutableHashSet();
-
-            public GraphModelImpl(
-                IGraphElementModel verticesModel,
-                IGraphElementModel edgesModel,
-                IGraphElementPropertyModel propertiesModel) : this(verticesModel, edgesModel, propertiesModel, DefaultNativeTypes)
-            {
-            }
-
-            private GraphModelImpl(IGraphElementModel verticesModel, IGraphElementModel edgesModel, IGraphElementPropertyModel propertiesModel, IImmutableSet<Type> nativeTypes)
+            public GraphModelImpl(IGraphElementModel verticesModel, IGraphElementModel edgesModel, IGraphElementPropertyModel propertiesModel)
             {
                 VerticesModel = verticesModel;
                 EdgesModel = edgesModel;
                 PropertiesModel = propertiesModel;
-                NativeTypes = nativeTypes;
-            }
-
-            public IGraphModel ConfigureNativeTypes(Func<IImmutableSet<Type>, IImmutableSet<Type>> transformation)
-            {
-                return new GraphModelImpl(
-                    VerticesModel,
-                    EdgesModel,
-                    PropertiesModel,
-                    transformation(NativeTypes));
             }
 
             public IGraphModel ConfigureVertices(Func<IGraphElementModel, IGraphElementModel> transformation)
@@ -57,8 +19,7 @@ namespace ExRam.Gremlinq.Core.Models
                 return new GraphModelImpl(
                     transformation(VerticesModel),
                     EdgesModel,
-                    PropertiesModel,
-                    NativeTypes);
+                    PropertiesModel);
             }
 
             public IGraphModel ConfigureEdges(Func<IGraphElementModel, IGraphElementModel> transformation)
@@ -66,8 +27,7 @@ namespace ExRam.Gremlinq.Core.Models
                 return new GraphModelImpl(
                     VerticesModel,
                     transformation(EdgesModel),
-                    PropertiesModel,
-                    NativeTypes);
+                    PropertiesModel);
             }
 
             public IGraphModel ConfigureProperties(Func<IGraphElementPropertyModel, IGraphElementPropertyModel> transformation)
@@ -75,14 +35,12 @@ namespace ExRam.Gremlinq.Core.Models
                 return new GraphModelImpl(
                     VerticesModel,
                     EdgesModel,
-                    transformation(PropertiesModel),
-                    NativeTypes);
+                    transformation(PropertiesModel));
             }
 
             public IGraphElementModel VerticesModel { get; }
             public IGraphElementModel EdgesModel { get; }
             public IGraphElementPropertyModel PropertiesModel { get; }
-            public IImmutableSet<Type> NativeTypes { get; }
         }
 
         public static readonly IGraphModel Empty = new GraphModelImpl(

--- a/src/ExRam.Gremlinq.Core/Models/IGraphModel.cs
+++ b/src/ExRam.Gremlinq.Core/Models/IGraphModel.cs
@@ -7,11 +7,9 @@ namespace ExRam.Gremlinq.Core.Models
         IGraphModel ConfigureVertices(Func<IGraphElementModel, IGraphElementModel> transformation);
         IGraphModel ConfigureEdges(Func<IGraphElementModel, IGraphElementModel> transformation);
         IGraphModel ConfigureProperties(Func<IGraphElementPropertyModel, IGraphElementPropertyModel> transformation);
-        IGraphModel ConfigureNativeTypes(Func<IImmutableSet<Type>, IImmutableSet<Type>> transformation);
 
         IGraphElementModel VerticesModel { get; }
         IGraphElementModel EdgesModel { get; }
         IGraphElementPropertyModel PropertiesModel { get; }
-        IImmutableSet<Type> NativeTypes { get; }
     }
 }

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.Helpers.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.Helpers.cs
@@ -15,7 +15,7 @@ namespace ExRam.Gremlinq.Core
     {
         private IEnumerable<PropertyStep> GetPropertySteps(Key key, object value, bool allowExplicitCardinality)
         {
-            if (value is not Traversal && value is IEnumerable enumerable && !Environment.GetCache().FastNativeTypes.ContainsKey(value.GetType()))
+            if (value is not Traversal && value is IEnumerable enumerable && !Environment.SupportsType(value.GetType()))
             {
                 if (!allowExplicitCardinality)
                     throw new NotSupportedException($"A value of type {value.GetType()} is not supported for property '{key}'.");

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.cs
@@ -1216,7 +1216,7 @@ namespace ExRam.Gremlinq.Core
                         static (__, state) => __.Where(state.right),
                         (left: binary.Left, right: binary.Right)),
 
-                    _ when expression.TryToGremlinExpression(Environment.Model) is { } gremlinExpression => gremlinExpression.Equals(GremlinExpression.True)
+                    _ when expression.TryToGremlinExpression(Environment) is { } gremlinExpression => gremlinExpression.Equals(GremlinExpression.True)
                         ? this
                         : gremlinExpression.Equals(GremlinExpression.False)
                             ? None()
@@ -1390,7 +1390,7 @@ namespace ExRam.Gremlinq.Core
                                                 new FilterStep.ByTraversalStep(this
                                                     .Where(
                                                         KeyStep.Instance,
-                                                        ExpressionFragment.Create(parameterExpression, Environment.Model),
+                                                        ExpressionFragment.Create(parameterExpression, Environment),
                                                         default,
                                                         semantics,
                                                         right)));
@@ -1402,7 +1402,7 @@ namespace ExRam.Gremlinq.Core
                                                 new FilterStep.ByTraversalStep(this
                                                     .Where(
                                                         LabelStep.Instance,
-                                                        ExpressionFragment.Create(parameterExpression, Environment.Model),
+                                                        ExpressionFragment.Create(parameterExpression, Environment),
                                                         default,
                                                         semantics,
                                                         right)));

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.cs
@@ -1298,7 +1298,7 @@ namespace ExRam.Gremlinq.Core
                                         {
                                             if (leftMemberExpressionKey.RawKey is string stringKey)
                                             {
-                                                if (!Environment.GetCache().FastNativeTypes.ContainsKey(leftMemberExpression.Type))
+                                                if (!Environment.SupportsType(leftMemberExpression.Type))
                                                 {
                                                     return traversal
                                                         .Push(

--- a/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
+++ b/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
@@ -84,7 +84,7 @@ namespace ExRam.Gremlinq.Core.Serialization
                         else if (recurse.TryTransform(step, env, out Instruction? expandedInstruction))
                             AddInstruction(expandedInstruction, byteCode, env, recurse);
                     }
-                    
+
                     var span = traversal.Steps;
                     var byteCode = new Bytecode();
 
@@ -230,6 +230,11 @@ namespace ExRam.Gremlinq.Core.Serialization
             .Add(ConverterFactory
                 .Create<Key, string>(static (key, _, _) => key.RawKey as string)
                 .AutoRecurse<string>())
+            .Add(Create<byte[], string>(static (bytes, env, recurse) => !env.SupportsTypeNatively(typeof(byte[]))
+                ? recurse
+                    .TransformTo<string>()
+                    .From(Convert.ToBase64String(bytes), env)
+                : default))
             .Add(Create<P, P>(static (p, env, recurse) =>
             {
                 if (p.Value is null)

--- a/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
+++ b/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
@@ -235,6 +235,11 @@ namespace ExRam.Gremlinq.Core.Serialization
                     .TransformTo<string>()
                     .From(Convert.ToBase64String(bytes), env)
                 : default))
+             .Add(Create<TimeSpan, double>(static (t, env, recurse) => !env.SupportsTypeNatively(typeof(TimeSpan))
+                ? recurse
+                    .TransformTo<double>()
+                    .From(t.TotalMilliseconds, env)
+                : default(double?)))
             .Add(Create<P, P>(static (p, env, recurse) =>
             {
                 if (p.Value is null)

--- a/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
+++ b/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
@@ -237,7 +237,7 @@ namespace ExRam.Gremlinq.Core.Serialization
 
                 return new P(
                     p.OperatorName,
-                    p.Value is IEnumerable enumerable && !env.Model.NativeTypes.Contains(enumerable.GetType())
+                    p.Value is IEnumerable enumerable && !env.NativeTypes.Contains(enumerable.GetType())
                         ? enumerable
                             .Cast<object>()
                             .Select(x => recurse.TransformTo<object>().From(x, env))

--- a/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
+++ b/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
@@ -237,7 +237,7 @@ namespace ExRam.Gremlinq.Core.Serialization
 
                 return new P(
                     p.OperatorName,
-                    p.Value is IEnumerable enumerable && !env.GetCache().FastNativeTypes.ContainsKey(enumerable.GetType())
+                    p.Value is IEnumerable enumerable && !env.SupportsType(enumerable.GetType())
                         ? enumerable
                             .Cast<object>()
                             .Select(x => recurse.TransformTo<object>().From(x, env))

--- a/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
+++ b/src/ExRam.Gremlinq.Core/Serialization/Serializer.cs
@@ -237,7 +237,7 @@ namespace ExRam.Gremlinq.Core.Serialization
 
                 return new P(
                     p.OperatorName,
-                    p.Value is IEnumerable enumerable && !env.NativeTypes.Contains(enumerable.GetType())
+                    p.Value is IEnumerable enumerable && !env.GetCache().FastNativeTypes.ContainsKey(enumerable.GetType())
                         ? enumerable
                             .Cast<object>()
                             .Select(x => recurse.TransformTo<object>().From(x, env))

--- a/src/ExRam.Gremlinq.Providers.CosmosDb/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.CosmosDb/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -102,7 +102,8 @@ namespace ExRam.Gremlinq.Core
                             .SetValue(GremlinqOption.EdgeProjectionSteps, Traversal.Empty)
                             .SetValue(GremlinqOption.VertexPropertyProjectionSteps, Traversal.Empty))
                         .ConfigureNativeTypes(nativeTypes => nativeTypes
-                            .Remove(typeof(byte[])))
+                            .Remove(typeof(byte[]))
+                            .Remove(typeof(TimeSpan)))
                         .UseGraphSon2()
                         .ConfigureSerializer(serializer => serializer
                             .Add(ConverterFactory
@@ -154,9 +155,7 @@ namespace ExRam.Gremlinq.Core
                                         ? WorkaroundOrder.Decr
                                         : default)
                                 .AutoRecurse<WorkaroundOrder>())
-                            .PreferGroovySerialization())))
-                .ConfigureEnvironment(environment => environment
-                    .StoreTimeSpansAsNumbers());
+                            .PreferGroovySerialization())));
         }
     }
 }

--- a/src/ExRam.Gremlinq.Providers.CosmosDb/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.CosmosDb/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -101,6 +101,8 @@ namespace ExRam.Gremlinq.Core
                             .SetValue(GremlinqOption.VertexProjectionSteps, Traversal.Empty)
                             .SetValue(GremlinqOption.EdgeProjectionSteps, Traversal.Empty)
                             .SetValue(GremlinqOption.VertexPropertyProjectionSteps, Traversal.Empty))
+                        .ConfigureNativeTypes(nativeTypes => nativeTypes
+                            .Remove(typeof(byte[])))
                         .UseGraphSon2()
                         .ConfigureSerializer(serializer => serializer
                             .Add(ConverterFactory
@@ -154,7 +156,6 @@ namespace ExRam.Gremlinq.Core
                                 .AutoRecurse<WorkaroundOrder>())
                             .PreferGroovySerialization())))
                 .ConfigureEnvironment(environment => environment
-                    .StoreByteArraysAsBase64String()
                     .StoreTimeSpansAsNumbers());
         }
     }

--- a/src/ExRam.Gremlinq.Providers.JanusGraph/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.JanusGraph/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -41,9 +41,9 @@ namespace ExRam.Gremlinq.Core
                             .ConfigureVertexPropertyFeatures(_ => VertexPropertyFeatures.RemoveProperty | VertexPropertyFeatures.NumericIds | VertexPropertyFeatures.StringIds | VertexPropertyFeatures.Properties | VertexPropertyFeatures.BooleanValues | VertexPropertyFeatures.ByteValues | VertexPropertyFeatures.DoubleValues | VertexPropertyFeatures.FloatValues | VertexPropertyFeatures.IntegerValues | VertexPropertyFeatures.LongValues | VertexPropertyFeatures.StringValues)
                             .ConfigureEdgeFeatures(_ => EdgeFeatures.AddEdges | EdgeFeatures.RemoveEdges | EdgeFeatures.AddProperty | EdgeFeatures.RemoveProperty | EdgeFeatures.NumericIds | EdgeFeatures.StringIds | EdgeFeatures.UuidIds | EdgeFeatures.CustomIds | EdgeFeatures.AnyIds)
                             .ConfigureEdgePropertyFeatures(_ => EdgePropertyFeatures.Properties | EdgePropertyFeatures.BooleanValues | EdgePropertyFeatures.ByteValues | EdgePropertyFeatures.DoubleValues | EdgePropertyFeatures.FloatValues | EdgePropertyFeatures.IntegerValues | EdgePropertyFeatures.LongValues | EdgePropertyFeatures.StringValues))
-                        .UseGraphSon3()))
-                .ConfigureEnvironment(environment => environment
-                    .StoreByteArraysAsBase64String());
+                        .ConfigureNativeTypes(nativeTypes => nativeTypes
+                            .Remove(typeof(byte[])))
+                        .UseGraphSon3()));
         }
     }
 }

--- a/src/ExRam.Gremlinq.Providers.Neptune/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.Neptune/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -44,6 +44,8 @@ namespace ExRam.Gremlinq.Core
                             .ConfigureVertexPropertyFeatures(_ => VertexPropertyFeatures.RemoveProperty | VertexPropertyFeatures.NumericIds | VertexPropertyFeatures.StringIds | VertexPropertyFeatures.Properties | VertexPropertyFeatures.BooleanValues | VertexPropertyFeatures.ByteValues | VertexPropertyFeatures.DoubleValues | VertexPropertyFeatures.FloatValues | VertexPropertyFeatures.IntegerValues | VertexPropertyFeatures.LongValues | VertexPropertyFeatures.StringValues)
                             .ConfigureEdgeFeatures(_ => EdgeFeatures.AddEdges | EdgeFeatures.RemoveEdges | EdgeFeatures.UserSuppliedIds | EdgeFeatures.AddProperty | EdgeFeatures.RemoveProperty | EdgeFeatures.NumericIds | EdgeFeatures.StringIds | EdgeFeatures.UuidIds | EdgeFeatures.CustomIds | EdgeFeatures.AnyIds)
                             .ConfigureEdgePropertyFeatures(_ => EdgePropertyFeatures.Properties | EdgePropertyFeatures.BooleanValues | EdgePropertyFeatures.ByteValues | EdgePropertyFeatures.DoubleValues | EdgePropertyFeatures.FloatValues | EdgePropertyFeatures.IntegerValues | EdgePropertyFeatures.LongValues | EdgePropertyFeatures.StringValues))
+                        .ConfigureNativeTypes(nativeTypes => nativeTypes
+                            .Remove(typeof(byte[])))
                         .UseGraphSon3()
                         .ConfigureSerializer(serializer => serializer
                             .Add(ConverterFactory
@@ -52,8 +54,7 @@ namespace ExRam.Gremlinq.Core
                                     : default)
                                 .AutoRecurse<PropertyStep.ByKeyStep>()))))
                 .ConfigureEnvironment(environment => environment
-                    .StoreTimeSpansAsNumbers()
-                    .StoreByteArraysAsBase64String());
+                    .StoreTimeSpansAsNumbers());
         }
     }
 }

--- a/src/ExRam.Gremlinq.Providers.Neptune/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/ExRam.Gremlinq.Providers.Neptune/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -45,16 +45,15 @@ namespace ExRam.Gremlinq.Core
                             .ConfigureEdgeFeatures(_ => EdgeFeatures.AddEdges | EdgeFeatures.RemoveEdges | EdgeFeatures.UserSuppliedIds | EdgeFeatures.AddProperty | EdgeFeatures.RemoveProperty | EdgeFeatures.NumericIds | EdgeFeatures.StringIds | EdgeFeatures.UuidIds | EdgeFeatures.CustomIds | EdgeFeatures.AnyIds)
                             .ConfigureEdgePropertyFeatures(_ => EdgePropertyFeatures.Properties | EdgePropertyFeatures.BooleanValues | EdgePropertyFeatures.ByteValues | EdgePropertyFeatures.DoubleValues | EdgePropertyFeatures.FloatValues | EdgePropertyFeatures.IntegerValues | EdgePropertyFeatures.LongValues | EdgePropertyFeatures.StringValues))
                         .ConfigureNativeTypes(nativeTypes => nativeTypes
-                            .Remove(typeof(byte[])))
+                            .Remove(typeof(byte[]))
+                            .Remove(typeof(TimeSpan)))
                         .UseGraphSon3()
                         .ConfigureSerializer(serializer => serializer
                             .Add(ConverterFactory
                                 .Create<PropertyStep.ByKeyStep, PropertyStep.ByKeyStep>((step, env, recurse) => Cardinality.List.Equals(step.Cardinality)
                                     ? new PropertyStep.ByKeyStep(step.Key, step.Value, step.MetaProperties, Cardinality.Set)
                                     : default)
-                                .AutoRecurse<PropertyStep.ByKeyStep>()))))
-                .ConfigureEnvironment(environment => environment
-                    .StoreTimeSpansAsNumbers());
+                                .AutoRecurse<PropertyStep.ByKeyStep>()))));
         }
     }
 }

--- a/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/BulkSetConverterFactory.cs
+++ b/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/BulkSetConverterFactory.cs
@@ -11,7 +11,7 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
         {
             public bool TryConvert(JObject serialized, IGremlinQueryEnvironment environment, ITransformer recurse, [NotNullWhen(true)] out TTargetArray? value)
             {
-                if (!environment.GetCache().FastNativeTypes.ContainsKey(typeof(TTargetArray)))
+                if (!environment.SupportsType(typeof(TTargetArray)))
                 {
                     if (serialized.TryGetValue("@type", out var typeToken) && "g:BulkSet".Equals(typeToken.Value<string>(), StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/EnumerableConverterFactory.cs
+++ b/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/EnumerableConverterFactory.cs
@@ -31,7 +31,7 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
         {
             public bool TryConvert(JArray serialized, IGremlinQueryEnvironment environment, ITransformer recurse, [NotNullWhen(true)] out TTargetArray? value)
             {
-                if (!environment.GetCache().FastNativeTypes.ContainsKey(typeof(TTargetArray)))
+                if (!environment.SupportsType(typeof(TTargetArray)))
                 {
                     value = (TTargetArray)(object)GetEnumerable(serialized, environment, recurse).ToArray();
                     return true;

--- a/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/LabelLookupConverterFactory.cs
+++ b/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/LabelLookupConverterFactory.cs
@@ -20,11 +20,13 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
                     : default;
 
                 if (modelType != null && modelType != typeof(TTarget))
+                {
                     if (recurse.TryDeserialize(modelType).From(serialized, environment) is TTarget target)
                     {
                         value = target;
                         return true;
                     }
+                }
 
                 value = default;
                 return false;

--- a/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/NativeTypeConverterFactory.cs
+++ b/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/NativeTypeConverterFactory.cs
@@ -17,7 +17,7 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
                     return true;
                 }
 
-                if (environment.GetCache().FastNativeTypes.ContainsKey(typeof(TTarget)))
+                if (environment.SupportsType(typeof(TTarget)))
                     if (serialized.ToObject<TTarget>() is { } convertedSerializedValue)
                     {
                         value = convertedSerializedValue;

--- a/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/SingleItemArrayFallbackConverterFactory.cs
+++ b/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/SingleItemArrayFallbackConverterFactory.cs
@@ -10,7 +10,7 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
         {
             public bool TryConvert(TSource source, IGremlinQueryEnvironment environment, ITransformer recurse, [NotNullWhen(true)] out TTargetArray? value)
             {
-                if (!environment.GetCache().FastNativeTypes.ContainsKey(typeof(TTargetArray)) && recurse.TryTransform<TSource, TTargetArrayItem>(source, environment, out var typedValue))
+                if (!environment.SupportsType(typeof(TTargetArray)) && recurse.TryTransform<TSource, TTargetArrayItem>(source, environment, out var typedValue))
                 {
                     value = (TTargetArray)(object)new[] { typedValue };
                     return true;

--- a/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/TimeSpanConverterFactory.cs
+++ b/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/TimeSpanConverterFactory.cs
@@ -11,7 +11,11 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
         {
             return jValue.Type == JTokenType.String
                 ? XmlConvert.ToTimeSpan(jValue.Value<string>()!)
-                : default(TimeSpan?);
+                : jValue.Type == JTokenType.Float
+                    ? TimeSpan.FromMilliseconds(jValue.Value<double>())
+                    : jValue.Type == JTokenType.Integer
+                        ? TimeSpan.FromMilliseconds(jValue.Value<long>())
+                        : default(TimeSpan?);
         }
     }
 }

--- a/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/VertexPropertyExtractConverterFactory.cs
+++ b/src/ExRam.Gremlinq.Support.NewtonsoftJson/Converters/VertexPropertyExtractConverterFactory.cs
@@ -12,8 +12,7 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
         {
             public bool TryConvert(JToken serialized, IGremlinQueryEnvironment environment, ITransformer recurse, [NotNullWhen(true)] out TTarget? value)
             {
-                var nativeTypes = environment.GetCache().FastNativeTypes;
-                var isNativeType = nativeTypes.ContainsKey(typeof(TTarget)) || typeof(TTarget).IsEnum && nativeTypes.ContainsKey(typeof(TTarget).GetEnumUnderlyingType());
+                var isNativeType = environment.SupportsType(typeof(TTarget)) || typeof(TTarget).IsEnum && environment.SupportsType(typeof(TTarget).GetEnumUnderlyingType());
 
                 if (serialized is JObject jObject)
                 {

--- a/src/ExRam.Gremlinq.Support.NewtonsoftJson/Extensions/GremlinQueryEnvironmentExtensions.cs
+++ b/src/ExRam.Gremlinq.Support.NewtonsoftJson/Extensions/GremlinQueryEnvironmentExtensions.cs
@@ -197,9 +197,8 @@ namespace ExRam.Gremlinq.Core
         public static IGremlinQueryEnvironment RegisterNativeType<TNative, TSerialized>(this IGremlinQueryEnvironment environment, Func<TNative, IGremlinQueryEnvironment, ITransformer, TSerialized> serializer, Func<JValue, IGremlinQueryEnvironment, ITransformer, TNative> deserializer)
         {
             return environment
-                .ConfigureModel(_ => _
-                    .ConfigureNativeTypes(_ => _
-                        .Add(typeof(TNative))))
+                .ConfigureNativeTypes(_ => _
+                    .Add(typeof(TNative)))
                 .ConfigureSerializer(_ => _
                     .Add(new NativeTypeSerializerConverterFactory<TNative, TSerialized>(serializer)))
                 .ConfigureDeserializer(_ => _

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -539,6 +539,7 @@ namespace ExRam.Gremlinq.Core
         ExRam.Gremlinq.Core.IFeatureSet FeatureSet { get; }
         Microsoft.Extensions.Logging.ILogger Logger { get; }
         ExRam.Gremlinq.Core.Models.IGraphModel Model { get; }
+        System.Collections.Immutable.IImmutableSet<System.Type> NativeTypes { get; }
         ExRam.Gremlinq.Core.IGremlinqOptions Options { get; }
         ExRam.Gremlinq.Core.Transformation.ITransformer Serializer { get; }
         ExRam.Gremlinq.Core.IGremlinQueryEnvironment ConfigureDebugger(System.Func<ExRam.Gremlinq.Core.IGremlinQueryDebugger, ExRam.Gremlinq.Core.IGremlinQueryDebugger> debuggerTransformation);
@@ -547,6 +548,7 @@ namespace ExRam.Gremlinq.Core
         ExRam.Gremlinq.Core.IGremlinQueryEnvironment ConfigureFeatureSet(System.Func<ExRam.Gremlinq.Core.IFeatureSet, ExRam.Gremlinq.Core.IFeatureSet> featureSetTransformation);
         ExRam.Gremlinq.Core.IGremlinQueryEnvironment ConfigureLogger(System.Func<Microsoft.Extensions.Logging.ILogger, Microsoft.Extensions.Logging.ILogger> loggerTransformation);
         ExRam.Gremlinq.Core.IGremlinQueryEnvironment ConfigureModel(System.Func<ExRam.Gremlinq.Core.Models.IGraphModel, ExRam.Gremlinq.Core.Models.IGraphModel> modelTransformation);
+        ExRam.Gremlinq.Core.IGremlinQueryEnvironment ConfigureNativeTypes(System.Func<System.Collections.Immutable.IImmutableSet<System.Type>, System.Collections.Immutable.IImmutableSet<System.Type>> transformation);
         ExRam.Gremlinq.Core.IGremlinQueryEnvironment ConfigureOptions(System.Func<ExRam.Gremlinq.Core.IGremlinqOptions, ExRam.Gremlinq.Core.IGremlinqOptions> optionsTransformation);
         ExRam.Gremlinq.Core.IGremlinQueryEnvironment ConfigureSerializer(System.Func<ExRam.Gremlinq.Core.Transformation.ITransformer, ExRam.Gremlinq.Core.Transformation.ITransformer> serializerTransformation);
     }
@@ -1441,11 +1443,9 @@ namespace ExRam.Gremlinq.Core.Models
     public interface IGraphModel
     {
         ExRam.Gremlinq.Core.Models.IGraphElementModel EdgesModel { get; }
-        System.Collections.Immutable.IImmutableSet<System.Type> NativeTypes { get; }
         ExRam.Gremlinq.Core.Models.IGraphElementPropertyModel PropertiesModel { get; }
         ExRam.Gremlinq.Core.Models.IGraphElementModel VerticesModel { get; }
         ExRam.Gremlinq.Core.Models.IGraphModel ConfigureEdges(System.Func<ExRam.Gremlinq.Core.Models.IGraphElementModel, ExRam.Gremlinq.Core.Models.IGraphElementModel> transformation);
-        ExRam.Gremlinq.Core.Models.IGraphModel ConfigureNativeTypes(System.Func<System.Collections.Immutable.IImmutableSet<System.Type>, System.Collections.Immutable.IImmutableSet<System.Type>> transformation);
         ExRam.Gremlinq.Core.Models.IGraphModel ConfigureProperties(System.Func<ExRam.Gremlinq.Core.Models.IGraphElementPropertyModel, ExRam.Gremlinq.Core.Models.IGraphElementPropertyModel> transformation);
         ExRam.Gremlinq.Core.Models.IGraphModel ConfigureVertices(System.Func<ExRam.Gremlinq.Core.Models.IGraphElementModel, ExRam.Gremlinq.Core.Models.IGraphElementModel> transformation);
     }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -125,7 +125,6 @@ namespace ExRam.Gremlinq.Core
     {
         public static readonly ExRam.Gremlinq.Core.IGremlinQueryEnvironment Default;
         public static readonly ExRam.Gremlinq.Core.IGremlinQueryEnvironment Empty;
-        public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment StoreByteArraysAsBase64String(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment) { }
         public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment StoreTimeSpansAsNumbers(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment) { }
         public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment UseDebugger(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, ExRam.Gremlinq.Core.IGremlinQueryDebugger debugger) { }
         public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment UseDeserializer(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, ExRam.Gremlinq.Core.Transformation.ITransformer deserializer) { }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -125,7 +125,6 @@ namespace ExRam.Gremlinq.Core
     {
         public static readonly ExRam.Gremlinq.Core.IGremlinQueryEnvironment Default;
         public static readonly ExRam.Gremlinq.Core.IGremlinQueryEnvironment Empty;
-        public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment StoreTimeSpansAsNumbers(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment) { }
         public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment UseDebugger(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, ExRam.Gremlinq.Core.IGremlinQueryDebugger debugger) { }
         public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment UseDeserializer(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, ExRam.Gremlinq.Core.Transformation.ITransformer deserializer) { }
         public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment UseExecutor(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor executor) { }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -136,6 +136,11 @@ namespace ExRam.Gremlinq.Core
         public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment UseModel(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment source, ExRam.Gremlinq.Core.Models.IGraphModel model) { }
         public static ExRam.Gremlinq.Core.IGremlinQueryEnvironment UseSerializer(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, ExRam.Gremlinq.Core.Transformation.ITransformer serializer) { }
     }
+    public static class GremlinQueryEnvironmentExtensions
+    {
+        public static bool SupportsType(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, System.Type type) { }
+        public static bool SupportsTypeNatively(this ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment, System.Type type) { }
+    }
     public static class GremlinQueryExtensions
     {
         public static System.Threading.Tasks.ValueTask<TElement> FirstAsync<TElement>(this ExRam.Gremlinq.Core.IGremlinQueryBase<TElement> query, System.Threading.CancellationToken ct = default) { }


### PR DESCRIPTION
The notion of native types is a property of the provider and not so much of the GraphModel. So it moves from GraphModel to IGremlinQueryEnvironment. In StoreByteArraysAsBase64String, do not remove byte[] from native types. The previous removal was always overriden by a new model and thus ineffective.