### PR TITLE
IExecutor takes an IGremlinQueryBase

### DIFF
--- a/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutor.cs
+++ b/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutor.cs
@@ -6,14 +6,14 @@ namespace ExRam.Gremlinq.Core.Execution
     {
         private sealed class GremlinQueryExecutorImpl : IGremlinQueryExecutor
         {
-            private readonly Func<Bytecode, IGremlinQueryEnvironment, IAsyncEnumerable<object>> _factory;
+            private readonly Func<IGremlinQueryBase, IGremlinQueryEnvironment, IAsyncEnumerable<object>> _factory;
 
-            public GremlinQueryExecutorImpl(Func<Bytecode, IGremlinQueryEnvironment, IAsyncEnumerable<object>> factory)
+            public GremlinQueryExecutorImpl(Func<IGremlinQueryBase, IGremlinQueryEnvironment, IAsyncEnumerable<object>> factory)
             {
                 _factory = factory;
             }
 
-            public IAsyncEnumerable<object> Execute(Bytecode query, IGremlinQueryEnvironment environment)
+            public IAsyncEnumerable<object> Execute(IGremlinQueryBase query, IGremlinQueryEnvironment environment)
             {
                 return _factory(query, environment);
             }
@@ -22,17 +22,17 @@ namespace ExRam.Gremlinq.Core.Execution
         private sealed class TransformQueryGremlinQueryExecutor : IGremlinQueryExecutor
         {
             private readonly IGremlinQueryExecutor _baseExecutor;
-            private readonly Func<Bytecode, Bytecode> _transformation;
+            private readonly Func<IGremlinQueryBase, IGremlinQueryBase> _transformation;
 
-            public TransformQueryGremlinQueryExecutor(IGremlinQueryExecutor baseExecutor, Func<Bytecode, Bytecode> transformation)
+            public TransformQueryGremlinQueryExecutor(IGremlinQueryExecutor baseExecutor, Func<IGremlinQueryBase, IGremlinQueryBase> transformation)
             {
                 _transformation = transformation;
                 _baseExecutor = baseExecutor;
             }
 
-            public IAsyncEnumerable<object> Execute(Bytecode bytecode, IGremlinQueryEnvironment environment)
+            public IAsyncEnumerable<object> Execute(IGremlinQueryBase query, IGremlinQueryEnvironment environment)
             {
-                return _baseExecutor.Execute(_transformation(bytecode), environment);
+                return _baseExecutor.Execute(_transformation(query), environment);
             }
         }
 
@@ -47,9 +47,9 @@ namespace ExRam.Gremlinq.Core.Execution
                 _baseExecutor = baseExecutor;
             }
 
-            public IAsyncEnumerable<object> Execute(Bytecode bytecode, IGremlinQueryEnvironment environment)
+            public IAsyncEnumerable<object> Execute(IGremlinQueryBase query, IGremlinQueryEnvironment environment)
             {
-                return _transformation(_baseExecutor.Execute(bytecode, environment));
+                return _transformation(_baseExecutor.Execute(query, environment));
             }
         }
 
@@ -59,9 +59,9 @@ namespace ExRam.Gremlinq.Core.Execution
 
         public static readonly IGremlinQueryExecutor Empty = Create(static (_, _) => AsyncEnumerable.Empty<object>());
 
-        public static IGremlinQueryExecutor Create(Func<Bytecode, IGremlinQueryEnvironment, IAsyncEnumerable<object>> executor) => new GremlinQueryExecutorImpl(executor);
+        public static IGremlinQueryExecutor Create(Func<IGremlinQueryBase, IGremlinQueryEnvironment, IAsyncEnumerable<object>> executor) => new GremlinQueryExecutorImpl(executor);
 
-        public static IGremlinQueryExecutor TransformQuery(this IGremlinQueryExecutor baseExecutor, Func<Bytecode, Bytecode> transformation) => new TransformQueryGremlinQueryExecutor(baseExecutor, transformation);
+        public static IGremlinQueryExecutor TransformQuery(this IGremlinQueryExecutor baseExecutor, Func<IGremlinQueryBase, IGremlinQueryBase> transformation) => new TransformQueryGremlinQueryExecutor(baseExecutor, transformation);
 
         public static IGremlinQueryExecutor TransformResult(this IGremlinQueryExecutor baseExecutor, Func<IAsyncEnumerable<object>, IAsyncEnumerable<object>> transformation) => new TransformResultGremlinQueryExecutor(baseExecutor, transformation);
     }

--- a/src/ExRam.Gremlinq.Core/Execution/IGremlinQueryExecutor.cs
+++ b/src/ExRam.Gremlinq.Core/Execution/IGremlinQueryExecutor.cs
@@ -1,9 +1,7 @@
-﻿using Gremlin.Net.Process.Traversal;
-
-namespace ExRam.Gremlinq.Core.Execution
+﻿namespace ExRam.Gremlinq.Core.Execution
 {
     public interface IGremlinQueryExecutor
     {
-        IAsyncEnumerable<object> Execute(Bytecode bytecode, IGremlinQueryEnvironment environment);
+        IAsyncEnumerable<object> Execute(IGremlinQueryBase query, IGremlinQueryEnvironment environment);
     }
 }

--- a/src/ExRam.Gremlinq.Core/Extensions/GremlinQueryExecutorExtensions.cs
+++ b/src/ExRam.Gremlinq.Core/Extensions/GremlinQueryExecutorExtensions.cs
@@ -22,7 +22,7 @@ namespace ExRam.Gremlinq.Core.Execution
                 _shouldRetry = shouldRetry;
             }
 
-            public IAsyncEnumerable<object> Execute(Bytecode bytecode, IGremlinQueryEnvironment environment)
+            public IAsyncEnumerable<object> Execute(IGremlinQueryBase query, IGremlinQueryEnvironment environment)
             {
                 return AsyncEnumerable.Create(Core);
 
@@ -32,7 +32,7 @@ namespace ExRam.Gremlinq.Core.Execution
 
                     for (var i = 0; i < int.MaxValue; i++)
                     {
-                        await using (var enumerator = _baseExecutor.Execute(bytecode, environment).GetAsyncEnumerator(ct))
+                        await using (var enumerator = _baseExecutor.Execute(query, environment).GetAsyncEnumerator(ct))
                         {
                             while (true)
                             {
@@ -81,7 +81,7 @@ namespace ExRam.Gremlinq.Core.Execution
                 _exceptionTransformation = exceptionTransformation;
             }
 
-            public IAsyncEnumerable<object> Execute(Bytecode bytecode, IGremlinQueryEnvironment environment)
+            public IAsyncEnumerable<object> Execute(IGremlinQueryBase query, IGremlinQueryEnvironment environment)
             {
                 return AsyncEnumerable.Create(Core);
 
@@ -92,7 +92,7 @@ namespace ExRam.Gremlinq.Core.Execution
                     try
                     {
                         enumerator = _baseExecutor
-                            .Execute(bytecode, environment)
+                            .Execute(query, environment)
                             .GetAsyncEnumerator(ct);
                     }
                     catch (Exception ex)

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
@@ -212,9 +212,7 @@ namespace ExRam.Gremlinq.Core
 
         IAsyncEnumerable<TElement> IGremlinQueryBase<TElement>.ToAsyncEnumerable() => Environment.Executor
             .Execute(
-                Environment.Serializer
-                    .TransformTo<Bytecode>()
-                    .From(this, Environment),
+                this,
                 Environment)
             .Select(executionResult => Environment.Deserializer
                 .TransformTo<TElement>()

--- a/src/ExRam.Gremlinq.Providers.Core/WebSocketProviderConfigurator.cs
+++ b/src/ExRam.Gremlinq.Providers.Core/WebSocketProviderConfigurator.cs
@@ -25,7 +25,7 @@ namespace ExRam.Gremlinq.Providers.Core
                 _clientFactory = clientFactory;
             }
 
-            public IAsyncEnumerable<object> Execute(Bytecode bytecode, IGremlinQueryEnvironment environment)
+            public IAsyncEnumerable<object> Execute(IGremlinQueryBase query, IGremlinQueryEnvironment environment)
             {
                 return AsyncEnumerable.Create(Core);
 
@@ -45,7 +45,7 @@ namespace ExRam.Gremlinq.Providers.Core
                     var requestMessage = environment
                         .Serializer
                         .TransformTo<RequestMessage>()
-                        .From(bytecode, environment);
+                        .From(query, environment);
 
                     var maybeResults = await client
                         .SubmitAsync<object>(requestMessage, ct)

--- a/test/ExRam.Gremlinq.Core.Tests/QueryExecutionTest.cs
+++ b/test/ExRam.Gremlinq.Core.Tests/QueryExecutionTest.cs
@@ -209,23 +209,6 @@ namespace ExRam.Gremlinq.Core.Tests
         }
 
         [Fact]
-        public virtual async Task AddV_list_cardinality_id()
-        {
-            if (_g.Environment.FeatureSet.Supports(VertexFeatures.UserSuppliedIds))
-            {
-                await _g
-                    .ConfigureEnvironment(env => env
-                        .UseModel(GraphModel
-                            .FromBaseTypes<VertexWithListId, Edge>(lookup => lookup
-                                .IncludeAssembliesOfBaseTypes())))
-                    .AddV(new VertexWithListId { Id = new[] { "123", "456" } })
-                    .Awaiting(x => x.FirstAsync())
-                    .Should()
-                    .ThrowAsync<NotSupportedException>();
-            }
-        }
-
-        [Fact]
         public virtual async Task AddV_TimeFrame()
         {
             await _g

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -1188,8 +1188,8 @@ namespace ExRam.Gremlinq.Core.Execution
         public static readonly ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor Empty;
         public static readonly ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor Identity;
         public static readonly ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor Invalid;
-        public static ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor Create(System.Func<Gremlin.Net.Process.Traversal.Bytecode, ExRam.Gremlinq.Core.IGremlinQueryEnvironment, System.Collections.Generic.IAsyncEnumerable<object>> executor) { }
-        public static ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor TransformQuery(this ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor baseExecutor, System.Func<Gremlin.Net.Process.Traversal.Bytecode, Gremlin.Net.Process.Traversal.Bytecode> transformation) { }
+        public static ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor Create(System.Func<ExRam.Gremlinq.Core.IGremlinQueryBase, ExRam.Gremlinq.Core.IGremlinQueryEnvironment, System.Collections.Generic.IAsyncEnumerable<object>> executor) { }
+        public static ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor TransformQuery(this ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor baseExecutor, System.Func<ExRam.Gremlinq.Core.IGremlinQueryBase, ExRam.Gremlinq.Core.IGremlinQueryBase> transformation) { }
         public static ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor TransformResult(this ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor baseExecutor, System.Func<System.Collections.Generic.IAsyncEnumerable<object>, System.Collections.Generic.IAsyncEnumerable<object>> transformation) { }
     }
     public static class GremlinQueryExecutorExtensions
@@ -1199,7 +1199,7 @@ namespace ExRam.Gremlinq.Core.Execution
     }
     public interface IGremlinQueryExecutor
     {
-        System.Collections.Generic.IAsyncEnumerable<object> Execute(Gremlin.Net.Process.Traversal.Bytecode bytecode, ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment);
+        System.Collections.Generic.IAsyncEnumerable<object> Execute(ExRam.Gremlinq.Core.IGremlinQueryBase query, ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment);
     }
 }
 namespace ExRam.Gremlinq.Core.ExpressionParsing

--- a/test/ExRam.Gremlinq.Support.NewtonsoftJson.Tests/Extensions/GremlinQuerySourceExtensions.cs
+++ b/test/ExRam.Gremlinq.Support.NewtonsoftJson.Tests/Extensions/GremlinQuerySourceExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using ExRam.Gremlinq.Core.Execution;
 using ExRam.Gremlinq.Core.Serialization;
 using Gremlin.Net.Process.Traversal;
-
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -18,7 +17,7 @@ namespace ExRam.Gremlinq.Core.Tests
                 _json = json;
             }
 
-            public IAsyncEnumerable<object> Execute(Bytecode bytecode, IGremlinQueryEnvironment environment)
+            public IAsyncEnumerable<object> Execute(IGremlinQueryBase query, IGremlinQueryEnvironment environment)
             {
                 var token = JsonConvert.DeserializeObject<JToken>(
                     _json,

--- a/test/ExRam.Gremlinq.Support.NewtonsoftJson.Tests/IntegrationTestsBase.cs
+++ b/test/ExRam.Gremlinq.Support.NewtonsoftJson.Tests/IntegrationTestsBase.cs
@@ -3,8 +3,13 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using ExRam.Gremlinq.Core;
 using ExRam.Gremlinq.Core.Execution;
+using ExRam.Gremlinq.Core.Models;
 using ExRam.Gremlinq.Core.Tests;
 using ExRam.Gremlinq.Core.Transformation;
+using ExRam.Gremlinq.Tests.Entities;
+
+using FluentAssertions;
+
 using Newtonsoft.Json.Linq;
 
 namespace ExRam.Gremlinq.Support.NewtonsoftJson.Tests
@@ -44,6 +49,23 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson.Tests
             testOutputHelper,
             callerFilePath)
         {
+        }
+
+        [Fact]
+        public virtual async Task AddV_list_cardinality_id()
+        {
+            if (_g.Environment.FeatureSet.Supports(VertexFeatures.UserSuppliedIds))
+            {
+                await _g
+                    .ConfigureEnvironment(env => env
+                        .UseModel(GraphModel
+                            .FromBaseTypes<VertexWithListId, Edge>(lookup => lookup
+                                .IncludeAssembliesOfBaseTypes())))
+                    .AddV(new VertexWithListId { Id = new[] { "123", "456" } })
+                    .Awaiting(x => x.FirstAsync())
+                    .Should()
+                    .ThrowAsync<NotSupportedException>();
+            }
         }
 
         public override Task Verify<TElement>(IGremlinQueryBase<TElement> query) => base.Verify(query.Cast<JToken>());


### PR DESCRIPTION
...so that the serialization pipeline is really IGremlinQueryBase->RequestMessage, which opens up more opportunities to override behaviour.