### PR TITLE
IGremlinQueryExecutor.Execute does not need the environment.

### DIFF
--- a/src/ExRam.Gremlinq.Core/Execution/IGremlinQueryExecutor.cs
+++ b/src/ExRam.Gremlinq.Core/Execution/IGremlinQueryExecutor.cs
@@ -2,6 +2,6 @@
 {
     public interface IGremlinQueryExecutor
     {
-        IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query, IGremlinQueryEnvironment environment);
+        IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query);
     }
 }

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
@@ -208,7 +208,7 @@ namespace ExRam.Gremlinq.Core
         GremlinQueryAwaiter<TElement> IGremlinQueryBase<TElement>.GetAwaiter() => new((this).ToArrayAsync().AsTask().GetAwaiter());
 
         IAsyncEnumerable<TElement> IGremlinQueryBase<TElement>.ToAsyncEnumerable() => Environment.Executor
-            .Execute<TElement>(this, Environment);
+            .Execute<TElement>(this);
 
         IValueGremlinQuery<Path> IGremlinQueryBase.Path() => Path();
 

--- a/src/ExRam.Gremlinq.Providers.Core/WebSocketProviderConfigurator.cs
+++ b/src/ExRam.Gremlinq.Providers.Core/WebSocketProviderConfigurator.cs
@@ -23,12 +23,16 @@ namespace ExRam.Gremlinq.Providers.Core
                 _clientFactory = clientFactory;
             }
 
-            public IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query, IGremlinQueryEnvironment environment)
+            public IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query)
             {
                 return AsyncEnumerable.Create(Core);
 
                 async IAsyncEnumerator<T> Core(CancellationToken ct)
                 {
+                    var environment = query
+                        .AsAdmin()
+                        .Environment;
+
                     var client = _clients
                         .GetOrAdd(
                             environment,

--- a/test/ExRam.Gremlinq.Core.Tests/Extensions/GremlinQueryExecutorExtensions.cs
+++ b/test/ExRam.Gremlinq.Core.Tests/Extensions/GremlinQueryExecutorExtensions.cs
@@ -11,10 +11,10 @@
                 _baseExecutor = baseExecutor;
             }
 
-            public IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query, IGremlinQueryEnvironment environment)
+            public IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query)
             {
                 return _baseExecutor
-                    .Execute<T>(query, environment)
+                    .Execute<T>(query)
                     .IgnoreElements();
             }
         }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -1193,7 +1193,7 @@ namespace ExRam.Gremlinq.Core.Execution
     }
     public interface IGremlinQueryExecutor
     {
-        System.Collections.Generic.IAsyncEnumerable<T> Execute<T>(ExRam.Gremlinq.Core.IGremlinQueryBase query, ExRam.Gremlinq.Core.IGremlinQueryEnvironment environment);
+        System.Collections.Generic.IAsyncEnumerable<T> Execute<T>(ExRam.Gremlinq.Core.IGremlinQueryBase query);
     }
 }
 namespace ExRam.Gremlinq.Core.ExpressionParsing

--- a/test/ExRam.Gremlinq.Support.NewtonsoftJson.Tests/Extensions/GremlinQueryExecutorExtensions.cs
+++ b/test/ExRam.Gremlinq.Support.NewtonsoftJson.Tests/Extensions/GremlinQueryExecutorExtensions.cs
@@ -13,8 +13,8 @@ namespace ExRam.Gremlinq.Core.Execution
                 _baseExecutor = baseExecutor;
             }
 
-            public IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query, IGremlinQueryEnvironment environment) => _baseExecutor
-                .Execute<T>(query, environment)
+            public IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query) => _baseExecutor
+                .Execute<T>(query)
                 .Catch<T, Exception>(ex => typeof(T).IsAssignableFrom(typeof(JObject))
                     ? AsyncEnumerableEx
                         .Return((T)(object)new JObject()


### PR DESCRIPTION
It's on the query.