### PR TITLE
Introduce a notion of ExecutionContext for GremlinQueries.

### DIFF
--- a/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutionContext.cs
+++ b/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutionContext.cs
@@ -1,0 +1,23 @@
+﻿namespace ExRam.Gremlinq.Core.Execution
+{
+    public readonly struct GremlinQueryExecutionContext
+    {
+        private readonly Guid? _executionId;
+        private readonly IGremlinQueryBase? _query;
+
+        public GremlinQueryExecutionContext(IGremlinQueryBase query) : this(query, Guid.NewGuid())
+        {
+
+        }
+
+        public GremlinQueryExecutionContext(IGremlinQueryBase query, Guid executionId)
+        {
+            _query = query;
+            _executionId = executionId;
+        }
+
+        public Guid ExecutionId => _executionId ?? throw new InvalidOperationException();
+
+        public IGremlinQueryBase Query => _query ?? throw new InvalidOperationException();
+    }
+}

--- a/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutionContext.cs
+++ b/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutionContext.cs
@@ -5,19 +5,20 @@
         private readonly Guid? _executionId;
         private readonly IGremlinQueryBase? _query;
 
-        public GremlinQueryExecutionContext(IGremlinQueryBase query) : this(query, Guid.NewGuid())
-        {
-
-        }
-
-        public GremlinQueryExecutionContext(IGremlinQueryBase query, Guid executionId)
+        private GremlinQueryExecutionContext(IGremlinQueryBase query, Guid executionId)
         {
             _query = query;
             _executionId = executionId;
         }
 
+        public GremlinQueryExecutionContext WithNewExecutionId() => new(Query, Guid.NewGuid());
+
+        public GremlinQueryExecutionContext TransformQuery(Func<IGremlinQueryBase, IGremlinQueryBase> transformation) => new(transformation(Query), ExecutionId);
+
         public Guid ExecutionId => _executionId ?? throw new InvalidOperationException();
 
         public IGremlinQueryBase Query => _query ?? throw new InvalidOperationException();
+
+        public static GremlinQueryExecutionContext Create(IGremlinQueryBase query) => new(query, Guid.NewGuid());
     }
 }

--- a/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutor.cs
+++ b/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutor.cs
@@ -82,7 +82,9 @@ namespace ExRam.Gremlinq.Core.Execution
                                     //requests fail roughly at the same time
                                     await Task.Delay((_rnd ??= new Random((int)(DateTime.Now.Ticks & int.MaxValue) ^ Thread.CurrentThread.ManagedThreadId)).Next(i + 2) * 16, ct);
 
-                                    environment.Logger.LogInformation($"Retrying query.");
+                                    var newContext = new GremlinQueryExecutionContext(context.Query);
+                                    environment.Logger.LogInformation($"Retrying serialized query {newContext.ExecutionId} with new {nameof(GremlinQueryExecutionContext.ExecutionId)} {newContext.ExecutionId}.");
+                                    context = newContext;
 
                                     break;
                                 }

--- a/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutor.cs
+++ b/src/ExRam.Gremlinq.Core/Execution/GremlinQueryExecutor.cs
@@ -28,7 +28,7 @@ namespace ExRam.Gremlinq.Core.Execution
                 _baseExecutor = baseExecutor;
             }
 
-            public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context) => _baseExecutor.Execute<T>(new GremlinQueryExecutionContext(_transformation(context.Query), context.ExecutionId));
+            public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context) => _baseExecutor.Execute<T>(context.TransformQuery(_transformation));
         }
 
         private sealed class ExponentialBackoffExecutor : IGremlinQueryExecutor
@@ -82,7 +82,7 @@ namespace ExRam.Gremlinq.Core.Execution
                                     //requests fail roughly at the same time
                                     await Task.Delay((_rnd ??= new Random((int)(DateTime.Now.Ticks & int.MaxValue) ^ Thread.CurrentThread.ManagedThreadId)).Next(i + 2) * 16, ct);
 
-                                    var newContext = new GremlinQueryExecutionContext(context.Query);
+                                    var newContext = context.WithNewExecutionId();
                                     environment.Logger.LogInformation($"Retrying serialized query {newContext.ExecutionId} with new {nameof(GremlinQueryExecutionContext.ExecutionId)} {newContext.ExecutionId}.");
                                     context = newContext;
 

--- a/src/ExRam.Gremlinq.Core/Execution/IGremlinQueryExecutor.cs
+++ b/src/ExRam.Gremlinq.Core/Execution/IGremlinQueryExecutor.cs
@@ -2,6 +2,6 @@
 {
     public interface IGremlinQueryExecutor
     {
-        IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query);
+        IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context);
     }
 }

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
@@ -210,7 +210,7 @@ namespace ExRam.Gremlinq.Core
         GremlinQueryAwaiter<TElement> IGremlinQueryBase<TElement>.GetAwaiter() => new((this).ToArrayAsync().AsTask().GetAwaiter());
 
         IAsyncEnumerable<TElement> IGremlinQueryBase<TElement>.ToAsyncEnumerable() => Environment.Executor
-            .Execute<TElement>(new GremlinQueryExecutionContext(this));
+            .Execute<TElement>(GremlinQueryExecutionContext.Create(this));
 
         IValueGremlinQuery<Path> IGremlinQueryBase.Path() => Path();
 

--- a/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
+++ b/src/ExRam.Gremlinq.Core/Queries/GremlinQuery.explicit.cs
@@ -3,6 +3,8 @@
 using System.Collections.Immutable;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+
+using ExRam.Gremlinq.Core.Execution;
 using ExRam.Gremlinq.Core.GraphElements;
 using ExRam.Gremlinq.Core.Projections;
 using ExRam.Gremlinq.Core.Steps;
@@ -208,7 +210,7 @@ namespace ExRam.Gremlinq.Core
         GremlinQueryAwaiter<TElement> IGremlinQueryBase<TElement>.GetAwaiter() => new((this).ToArrayAsync().AsTask().GetAwaiter());
 
         IAsyncEnumerable<TElement> IGremlinQueryBase<TElement>.ToAsyncEnumerable() => Environment.Executor
-            .Execute<TElement>(this);
+            .Execute<TElement>(new GremlinQueryExecutionContext(this));
 
         IValueGremlinQuery<Path> IGremlinQueryBase.Path() => Path();
 

--- a/src/ExRam.Gremlinq.Providers.Core/WebSocketProviderConfigurator.cs
+++ b/src/ExRam.Gremlinq.Providers.Core/WebSocketProviderConfigurator.cs
@@ -23,13 +23,13 @@ namespace ExRam.Gremlinq.Providers.Core
                 _clientFactory = clientFactory;
             }
 
-            public IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query)
+            public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context)
             {
                 return AsyncEnumerable.Create(Core);
 
                 async IAsyncEnumerator<T> Core(CancellationToken ct)
                 {
-                    var environment = query
+                    var environment = context.Query
                         .AsAdmin()
                         .Environment;
 
@@ -44,10 +44,14 @@ namespace ExRam.Gremlinq.Providers.Core
                                 static _ => { }),
                             this);
 
-                    var requestMessage = environment
+                    var requestMessageBuilder = environment
                         .Serializer
-                        .TransformTo<RequestMessage>()
-                        .From(query, environment);
+                        .TransformTo<RequestMessage.Builder>()
+                        .From(context.Query, environment);
+
+                    var requestMessage = requestMessageBuilder
+                        .OverrideRequestId(context.ExecutionId)
+                        .Create();
 
                     var maybeResults = await client
                         .SubmitAsync<object>(requestMessage, ct)

--- a/test/ExRam.Gremlinq.Core.Tests/Extensions/GremlinQueryExecutorExtensions.cs
+++ b/test/ExRam.Gremlinq.Core.Tests/Extensions/GremlinQueryExecutorExtensions.cs
@@ -11,10 +11,10 @@
                 _baseExecutor = baseExecutor;
             }
 
-            public IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query)
+            public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context)
             {
                 return _baseExecutor
-                    .Execute<T>(query)
+                    .Execute<T>(context)
                     .IgnoreElements();
             }
         }

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -1185,10 +1185,11 @@ namespace ExRam.Gremlinq.Core.Execution
 {
     public readonly struct GremlinQueryExecutionContext
     {
-        public GremlinQueryExecutionContext(ExRam.Gremlinq.Core.IGremlinQueryBase query) { }
-        public GremlinQueryExecutionContext(ExRam.Gremlinq.Core.IGremlinQueryBase query, System.Guid executionId) { }
         public System.Guid ExecutionId { get; }
         public ExRam.Gremlinq.Core.IGremlinQueryBase Query { get; }
+        public ExRam.Gremlinq.Core.Execution.GremlinQueryExecutionContext TransformQuery(System.Func<ExRam.Gremlinq.Core.IGremlinQueryBase, ExRam.Gremlinq.Core.IGremlinQueryBase> transformation) { }
+        public ExRam.Gremlinq.Core.Execution.GremlinQueryExecutionContext WithNewExecutionId() { }
+        public static ExRam.Gremlinq.Core.Execution.GremlinQueryExecutionContext Create(ExRam.Gremlinq.Core.IGremlinQueryBase query) { }
     }
     public static class GremlinQueryExecutor
     {

--- a/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
+++ b/test/ExRam.Gremlinq.PublicApi.Tests/PublicApiTests.Core.verified.cs
@@ -1183,6 +1183,13 @@ namespace ExRam.Gremlinq.Core
 }
 namespace ExRam.Gremlinq.Core.Execution
 {
+    public readonly struct GremlinQueryExecutionContext
+    {
+        public GremlinQueryExecutionContext(ExRam.Gremlinq.Core.IGremlinQueryBase query) { }
+        public GremlinQueryExecutionContext(ExRam.Gremlinq.Core.IGremlinQueryBase query, System.Guid executionId) { }
+        public System.Guid ExecutionId { get; }
+        public ExRam.Gremlinq.Core.IGremlinQueryBase Query { get; }
+    }
     public static class GremlinQueryExecutor
     {
         public static readonly ExRam.Gremlinq.Core.Execution.IGremlinQueryExecutor Empty;
@@ -1193,7 +1200,7 @@ namespace ExRam.Gremlinq.Core.Execution
     }
     public interface IGremlinQueryExecutor
     {
-        System.Collections.Generic.IAsyncEnumerable<T> Execute<T>(ExRam.Gremlinq.Core.IGremlinQueryBase query);
+        System.Collections.Generic.IAsyncEnumerable<T> Execute<T>(ExRam.Gremlinq.Core.Execution.GremlinQueryExecutionContext context);
     }
 }
 namespace ExRam.Gremlinq.Core.ExpressionParsing

--- a/test/ExRam.Gremlinq.Support.NewtonsoftJson.Tests/Extensions/GremlinQueryExecutorExtensions.cs
+++ b/test/ExRam.Gremlinq.Support.NewtonsoftJson.Tests/Extensions/GremlinQueryExecutorExtensions.cs
@@ -13,8 +13,8 @@ namespace ExRam.Gremlinq.Core.Execution
                 _baseExecutor = baseExecutor;
             }
 
-            public IAsyncEnumerable<T> Execute<T>(IGremlinQueryBase query) => _baseExecutor
-                .Execute<T>(query)
+            public IAsyncEnumerable<T> Execute<T>(GremlinQueryExecutionContext context) => _baseExecutor
+                .Execute<T>(context)
                 .Catch<T, Exception>(ex => typeof(T).IsAssignableFrom(typeof(JObject))
                     ? AsyncEnumerableEx
                         .Return((T)(object)new JObject()


### PR DESCRIPTION
It'll carry the query and an Id. Rework the serializer to produce RequestMessage.Builders. Add a convenience serializer from builder to message for the tests.