### PR TITLE
VertexOrEdgeConverterFactory must only work on types it know from the model. 

### DIFF
--- a/src/Support.NewtonsoftJson/Converters/VertexOrEdgeConverterFactory.cs
+++ b/src/Support.NewtonsoftJson/Converters/VertexOrEdgeConverterFactory.cs
@@ -35,9 +35,13 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
 
         public IConverter<TSource, TTarget>? TryCreate<TSource, TTarget>(IGremlinQueryEnvironment environment)
         {
-            return typeof(TSource) == typeof(JObject) && !typeof(TTarget).IsAssignableFrom(typeof(TSource)) && !typeof(TTarget).IsArray && typeof(TTarget) != typeof(object) && !typeof(TTarget).IsInterface && !typeof(Property).IsAssignableFrom(typeof(TTarget))
-                ? (IConverter<TSource, TTarget>)(object)new VertexOrEdgeConverter<TTarget>(environment)
-                : default;
+            if (typeof(TSource) == typeof(JObject) && !typeof(TTarget).IsAssignableFrom(typeof(TSource)) && !typeof(TTarget).IsArray && typeof(TTarget) != typeof(object) && !typeof(TTarget).IsInterface && !typeof(Property).IsAssignableFrom(typeof(TTarget)))
+            {
+                if (environment.Model.VerticesModel.Metadata.Keys.Concat(environment.Model.EdgesModel.Metadata.Keys).Any(type => type.IsAssignableFrom(typeof(TTarget))))
+                    return (IConverter<TSource, TTarget>)(object)new VertexOrEdgeConverter<TTarget>(environment);
+            }
+
+            return default;
         }
     }
 }

--- a/test/Providers.CosmosDb.Tests/DeserializationTests.AddV_without_model.verified.txt
+++ b/test/Providers.CosmosDb.Tests/DeserializationTests.AddV_without_model.verified.txt
@@ -1,6 +1,5 @@
 ﻿[
   {
-    IetfLanguageTag: en,
     Id: 00000000-0000-0000-0000-000000000000,
     Label: Language
   }

--- a/test/Providers.GremlinServer.Tests/DeserializationTests.AddV_without_model.verified.txt
+++ b/test/Providers.GremlinServer.Tests/DeserializationTests.AddV_without_model.verified.txt
@@ -1,6 +1,5 @@
 ﻿[
   {
-    IetfLanguageTag: en,
     Id: -1,
     Label: Language
   }

--- a/test/Support.NewtonsoftJson.Tests/GraphsonSupportTest.Language_strongly_typed_without_model.verified.txt
+++ b/test/Support.NewtonsoftJson.Tests/GraphsonSupportTest.Language_strongly_typed_without_model.verified.txt
@@ -1,6 +1,5 @@
 ﻿[
   {
-    IetfLanguageTag: de,
     Id: 10,
     Label: Language
   }


### PR DESCRIPTION
That means no magic for empty models any more.