### PR TITLE
Remove dependency on System.Linq.Async.

### DIFF
--- a/src/Core/ExRam.Gremlinq.Core.csproj
+++ b/src/Core/ExRam.Gremlinq.Core.csproj
@@ -6,7 +6,7 @@
   
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFramework)'=='netstandard2.1'" Version="1.7.1" />
-    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+    <!--<PackageReference Include="System.Linq.Async" Version="5.0.0" />-->
     <PackageReference Include="Gremlin.Net" Version="3.6.4" />
   </ItemGroup>
 

--- a/src/Core/Execution/GremlinQueryExecutor.cs
+++ b/src/Core/Execution/GremlinQueryExecutor.cs
@@ -1,4 +1,5 @@
-﻿using Gremlin.Net.Driver.Exceptions;
+﻿using System.Linq.Async;
+using Gremlin.Net.Driver.Exceptions;
 using Microsoft.Extensions.Logging;
 
 namespace ExRam.Gremlinq.Core.Execution

--- a/src/Core/Extensions/AsyncEnumerable.cs
+++ b/src/Core/Extensions/AsyncEnumerable.cs
@@ -1,0 +1,119 @@
+﻿namespace System.Linq.Async
+{
+    internal static class AsyncEnumerable
+    {
+        private const string NoElements = "Source sequence doesn't contain any elements.";
+        private const string MoreThanOneElement = "Source sequence contains more than one element.";
+
+        private sealed class AnonymousAsyncEnumerable<T> : IAsyncEnumerable<T>
+        {
+            private readonly Func<CancellationToken, IAsyncEnumerator<T>> _enumeratorFactory;
+
+            public AnonymousAsyncEnumerable(Func<CancellationToken, IAsyncEnumerator<T>> enumeratorFactory) => _enumeratorFactory = enumeratorFactory;
+
+            public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken ct)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                return _enumeratorFactory(ct);
+            }
+        }
+
+        public static IAsyncEnumerable<T> Empty<T>()
+        {
+            return Create(Core);
+
+            static async IAsyncEnumerator<T> Core(CancellationToken ct)
+            {
+                yield break;
+            }
+        }
+
+        public static IAsyncEnumerable<T> Create<T>(Func<CancellationToken, IAsyncEnumerator<T>> enumeratorFactory)
+        {
+            return new AnonymousAsyncEnumerable<T>(enumeratorFactory);
+        }
+
+        public static async ValueTask<TSource?> FirstOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, CancellationToken ct = default)
+        {
+            await foreach (var item in source.WithCancellation(ct).ConfigureAwait(false))
+            {
+                return item;
+            }
+
+            return default;
+        }
+
+        public static async ValueTask<TSource?> LastOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, CancellationToken ct = default)
+        {
+            var hasLast = false;
+            var last = default(TSource)!;
+
+            await foreach (var item in source.WithCancellation(ct).ConfigureAwait(false))
+            {
+                last = item;
+                hasLast = true;
+            }
+
+            return hasLast
+                ? last
+                : default;
+        }
+
+        public static async ValueTask<TSource> FirstAsync<TSource>(this IAsyncEnumerable<TSource> source, CancellationToken ct = default)
+        {
+            await foreach (var item in source.WithCancellation(ct).ConfigureAwait(false))
+            {
+                return item;
+            }
+
+            throw new InvalidOperationException(NoElements);
+        }
+
+        public static async ValueTask<TSource> SingleAsync<TSource>(this IAsyncEnumerable<TSource> source, CancellationToken ct = default)
+        {
+            await using (var e = source.WithCancellation(ct).ConfigureAwait(false).GetAsyncEnumerator())
+            {
+                if (!await e.MoveNextAsync())
+                    throw new InvalidOperationException(NoElements);
+
+                var result = e.Current;
+
+                if (await e.MoveNextAsync())
+                    throw new InvalidOperationException(MoreThanOneElement);
+
+                return result;
+            }
+        }
+
+        public static async ValueTask<TSource?> SingleOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, CancellationToken ct = default)
+        {
+            await using (var e = source.WithCancellation(ct).ConfigureAwait(false).GetAsyncEnumerator())
+            {
+                if (!await e.MoveNextAsync())
+                    throw new InvalidOperationException(NoElements);
+
+                var result = e.Current;
+
+                if (await e.MoveNextAsync())
+                    return default;
+
+                return result;
+            }
+        }
+
+        public static async ValueTask<TSource[]> ToArrayAsync<TSource>(this IAsyncEnumerable<TSource> source, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var list = new List<TSource>();
+
+            await foreach (var item in source.WithCancellation(ct).ConfigureAwait(false))
+            {
+                list.Add(item);
+            }
+
+            return list.ToArray();
+        }
+    }
+}

--- a/src/Core/Extensions/EnumerableExtensions.cs
+++ b/src/Core/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Linq.Async;
 using ExRam.Gremlinq.Core.Projections;
 using ExRam.Gremlinq.Core.Steps;
 

--- a/src/Core/Extensions/GremlinQueryExtensions.cs
+++ b/src/Core/Extensions/GremlinQueryExtensions.cs
@@ -1,4 +1,5 @@
-﻿using ExRam.Gremlinq.Core.Steps;
+﻿using System.Linq.Async;
+using ExRam.Gremlinq.Core.Steps;
 
 namespace ExRam.Gremlinq.Core
 {

--- a/src/Core/Queries/GremlinQuery.explicit.cs
+++ b/src/Core/Queries/GremlinQuery.explicit.cs
@@ -1,6 +1,7 @@
 ﻿// ReSharper disable ArrangeThisQualifier
 // ReSharper disable CoVariantArrayConversion
 using System.Collections.Immutable;
+using System.Linq.Async;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using ExRam.Gremlinq.Core.Execution;


### PR DESCRIPTION
It can't currently be updated due to a bug (https://github.com/dotnet/reactive/pull/1941) and the utilized operators are rather trivial to re-implement here. The dll is over 1MB.