### PR TITLE
Disable collection parallelization

### DIFF
--- a/test/AssemblyInfo.cs
+++ b/test/AssemblyInfo.cs
@@ -1,1 +1,1 @@
-﻿
+﻿[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
...since two test containers running at the same time is often too much for the Github actions runner.