### PR TITLE
Don't deal with RequestMessage.Builder in the serializers.

### DIFF
--- a/src/Providers.Core/Extensions/RequestMessageBuilderExtensions.cs
+++ b/src/Providers.Core/Extensions/RequestMessageBuilderExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Gremlin.Net.Driver.Messages;
+
+namespace Gremlin.Net.Driver
+{
+    internal static class RequestMessageBuilderExtensions
+    {
+        public static RequestMessage.Builder AddArguments(this RequestMessage.Builder builder, IEnumerable<KeyValuePair<string, object>> arguments)
+        {
+            foreach (var argument in arguments)
+            {
+                builder = builder
+                    .AddArgument(argument.Key, argument.Value);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/src/Providers.Core/Extensions/RequestMessageBuilderExtensions.cs
+++ b/src/Providers.Core/Extensions/RequestMessageBuilderExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Gremlin.Net.Driver.Messages;
-
-namespace Gremlin.Net.Driver
+﻿namespace Gremlin.Net.Driver.Messages
 {
     internal static class RequestMessageBuilderExtensions
     {

--- a/src/Providers.Core/Extensions/RequestMessageExtensions.cs
+++ b/src/Providers.Core/Extensions/RequestMessageExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Immutable;
+
 using ExRam.Gremlinq.Core;
 using ExRam.Gremlinq.Core.Serialization;
+
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Process.Traversal;
 
@@ -29,5 +31,11 @@ namespace Gremlin.Net.Driver
 
             return default;
         }
+
+        public static RequestMessage.Builder Rebuild(this RequestMessage message) => RequestMessage
+            .Build(message.Operation)
+            .OverrideRequestId(message.RequestId)
+            .Processor(message.Processor)
+            .AddArguments(message.Arguments);
     }
 }

--- a/src/Providers.Core/Extensions/RequestMessageExtensions.cs
+++ b/src/Providers.Core/Extensions/RequestMessageExtensions.cs
@@ -6,7 +6,7 @@ using ExRam.Gremlinq.Core.Serialization;
 using Gremlin.Net.Driver.Messages;
 using Gremlin.Net.Process.Traversal;
 
-namespace Gremlin.Net.Driver
+namespace Gremlin.Net.Driver.Messages
 {
     internal static class RequestMessageExtensions
     {

--- a/src/Providers.Core/WebSocketProviderConfigurator.cs
+++ b/src/Providers.Core/WebSocketProviderConfigurator.cs
@@ -49,12 +49,11 @@ namespace ExRam.Gremlinq.Providers.Core
                                 static _ => { }),
                             @this);
 
-                    var requestMessageBuilder = environment
+                    var requestMessage = environment
                         .Serializer
-                        .TransformTo<RequestMessage.Builder>()
-                        .From(context.Query, environment);
-
-                    var requestMessage = requestMessageBuilder
+                        .TransformTo<RequestMessage>()
+                        .From(context.Query, environment)
+                        .Rebuild()
                         .OverrideRequestId(context.ExecutionId)
                         .Create();
 


### PR DESCRIPTION
If a message must be changed, use the Rebuild extension.