### PR TITLE
Push IdentityStep magic back into continuations

### DIFF
--- a/src/Core/Queries/GremlinQuery.cs
+++ b/src/Core/Queries/GremlinQuery.cs
@@ -622,7 +622,7 @@ namespace ExRam.Gremlinq.Core
             .With(localTraversal)
             .Build(static (builder, continuationTraversal) =>
             {
-                if (continuationTraversal.Count > 0)
+                if (!continuationTraversal.IsIdentity())
                 {
                     builder = builder
                         .AddStep(new LocalStep(continuationTraversal))

--- a/src/Core/Serialization/Serializer.cs
+++ b/src/Core/Serialization/Serializer.cs
@@ -284,9 +284,6 @@ namespace ExRam.Gremlinq.Core.Serialization
                             else
                                 AddStep(step, byteCode, isSourceStep, env, recurse);
                         }
-
-                        if (byteCode.StepInstructions.Count == 0)
-                            AddStep(IdentityStep.Instance, byteCode, false, env, recurse);
                     }
 
                     return new Bytecode()


### PR DESCRIPTION
Appending an otherwise empty traversal during serialization is too late as no information on whether we're on the top-level query is available. For whenever the steps on an IGremlinQuerySource are empty (but the source-steps aren't), we get a wrong call on Identity() on the source.