### PR TITLE
The social media preview of the release page is utter boring.

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -18,7 +18,7 @@ jobs:
           
             ExRam.Gremlinq is the first #dotnet object-graph-mapper for @apachetinkerpop #gremlin enabled #graphdb​s like @AzureCosmosDB, @dotnetonAWS Neptune or @JanusGraph.
           
-            ${{ github.event.release.html_url }}
+            https://github.com/${{github.repository}}
           consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
           consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
           access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}


### PR DESCRIPTION
Change it to the repo url.