### PR TITLE
Supress suggestions to use collection expressions.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,7 @@
 
     <Product>ExRam.Gremlinq</Product>
     <Deterministic>true</Deterministic>
+    <NoWarn>IDE0303;IDE0301$(NoWarn)</NoWarn>
     <WeaverConfiguration>
       <Weavers>
         <NullGuard />


### PR DESCRIPTION
They are not usable on anything < .NET 8. They would be usable with an explicit reference to the System.Collections.Immutable nuget, but that's something I am not willing to do just for syntactic sugar.