### PR TITLE
Allow `IPoolGremlinqClientFactory.ConfigureBaseFactory` to transform to a different factory type

### DIFF
--- a/src/Providers.Core/Factory/GremlinqClientFactory.cs
+++ b/src/Providers.Core/Factory/GremlinqClientFactory.cs
@@ -146,7 +146,7 @@ namespace ExRam.Gremlinq.Providers.Core
                 _maxInProcessPerConnection = maxInProcessPerConnection;
             }
 
-            public IPoolGremlinqClientFactory<TBaseFactory> ConfigureBaseFactory(Func<TBaseFactory, TBaseFactory> transformation) => new PoolGremlinqClientFactory<TBaseFactory>(transformation(_baseFactory));
+            public IPoolGremlinqClientFactory<TNewBaseFactory> ConfigureBaseFactory<TNewBaseFactory>(Func<TBaseFactory, TNewBaseFactory> transformation) where TNewBaseFactory : IGremlinqClientFactory => new PoolGremlinqClientFactory<TNewBaseFactory>(transformation(_baseFactory));
 
             public IPoolGremlinqClientFactory<TBaseFactory> WithMaxInProcessPerConnection(int maxInProcessPerConnection) => maxInProcessPerConnection is > 0 and <= 64
                 ? new PoolGremlinqClientFactory<TBaseFactory>(_baseFactory, _poolSize, maxInProcessPerConnection)

--- a/src/Providers.Core/Factory/IPoolGremlinqClientFactory.cs
+++ b/src/Providers.Core/Factory/IPoolGremlinqClientFactory.cs
@@ -3,7 +3,8 @@
     public interface IPoolGremlinqClientFactory<TBaseFactory> : IGremlinqClientFactory
         where TBaseFactory : IGremlinqClientFactory
     {
-        IPoolGremlinqClientFactory<TBaseFactory> ConfigureBaseFactory(Func<TBaseFactory, TBaseFactory> transformation);
+        IPoolGremlinqClientFactory<TNewBaseFactory> ConfigureBaseFactory<TNewBaseFactory>(Func<TBaseFactory, TNewBaseFactory> transformation)
+            where TNewBaseFactory : IGremlinqClientFactory;
 
         IPoolGremlinqClientFactory<TBaseFactory> WithPoolSize(int poolSize);
 

--- a/test/Providers.Core.Tests/ClientFactoryTests.cs
+++ b/test/Providers.Core.Tests/ClientFactoryTests.cs
@@ -1,0 +1,21 @@
+﻿#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+using NSubstitute;
+
+namespace ExRam.Gremlinq.Providers.Core.Tests
+{
+    public class ClientFactoryTests
+    {
+        [Fact]
+        public void Configured_base_factory_doesnt_have_to_be_same_type()
+        {
+            var baseFactory = Substitute
+                .For<IWebSocketGremlinqClientFactory>();
+
+            var poolClient = baseFactory
+                .Pool()
+                .ConfigureBaseFactory(factory => factory
+                    .ConfigureClient(client => client));
+        }
+    }
+}

--- a/test/PublicApi.Tests/PublicApiTests.ProvidersCore.DotNet6_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.ProvidersCore.DotNet6_0.verified.cs
@@ -41,7 +41,8 @@
     public interface IPoolGremlinqClientFactory<TBaseFactory> : ExRam.Gremlinq.Providers.Core.IGremlinqClientFactory
         where TBaseFactory : ExRam.Gremlinq.Providers.Core.IGremlinqClientFactory
     {
-        ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TBaseFactory> ConfigureBaseFactory(System.Func<TBaseFactory, TBaseFactory> transformation);
+        ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TNewBaseFactory> ConfigureBaseFactory<TNewBaseFactory>(System.Func<TBaseFactory, TNewBaseFactory> transformation)
+            where TNewBaseFactory : ExRam.Gremlinq.Providers.Core.IGremlinqClientFactory;
         ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TBaseFactory> WithMaxInProcessPerConnection(int maxInProcessPerConnection);
         ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TBaseFactory> WithPoolSize(int poolSize);
     }

--- a/test/PublicApi.Tests/PublicApiTests.ProvidersCore.DotNet7_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.ProvidersCore.DotNet7_0.verified.cs
@@ -41,7 +41,8 @@
     public interface IPoolGremlinqClientFactory<TBaseFactory> : ExRam.Gremlinq.Providers.Core.IGremlinqClientFactory
         where TBaseFactory : ExRam.Gremlinq.Providers.Core.IGremlinqClientFactory
     {
-        ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TBaseFactory> ConfigureBaseFactory(System.Func<TBaseFactory, TBaseFactory> transformation);
+        ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TNewBaseFactory> ConfigureBaseFactory<TNewBaseFactory>(System.Func<TBaseFactory, TNewBaseFactory> transformation)
+            where TNewBaseFactory : ExRam.Gremlinq.Providers.Core.IGremlinqClientFactory;
         ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TBaseFactory> WithMaxInProcessPerConnection(int maxInProcessPerConnection);
         ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TBaseFactory> WithPoolSize(int poolSize);
     }

--- a/test/PublicApi.Tests/PublicApiTests.ProvidersCore.DotNet8_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.ProvidersCore.DotNet8_0.verified.cs
@@ -41,7 +41,8 @@
     public interface IPoolGremlinqClientFactory<TBaseFactory> : ExRam.Gremlinq.Providers.Core.IGremlinqClientFactory
         where TBaseFactory : ExRam.Gremlinq.Providers.Core.IGremlinqClientFactory
     {
-        ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TBaseFactory> ConfigureBaseFactory(System.Func<TBaseFactory, TBaseFactory> transformation);
+        ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TNewBaseFactory> ConfigureBaseFactory<TNewBaseFactory>(System.Func<TBaseFactory, TNewBaseFactory> transformation)
+            where TNewBaseFactory : ExRam.Gremlinq.Providers.Core.IGremlinqClientFactory;
         ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TBaseFactory> WithMaxInProcessPerConnection(int maxInProcessPerConnection);
         ExRam.Gremlinq.Providers.Core.IPoolGremlinqClientFactory<TBaseFactory> WithPoolSize(int poolSize);
     }


### PR DESCRIPTION
This change is

✅ source compatible
❌ not binary compatible

Applications must be recompiled.