### PR TITLE
Remove CosmosDb _attachments system property.

### DIFF
--- a/src/Providers.CosmosDb/SystemProperty.cs
+++ b/src/Providers.CosmosDb/SystemProperty.cs
@@ -6,7 +6,6 @@
         public static readonly SystemProperty _rid = new(nameof(_rid));
         public static readonly SystemProperty _etag = new(nameof(_etag));
         public static readonly SystemProperty _self = new(nameof(_self));
-        public static readonly SystemProperty _attachments = new(nameof(_attachments));
         public static readonly SystemProperty inVPartition = new(nameof(inVPartition));
         public static readonly SystemProperty outVPartition = new(nameof(outVPartition));
 

--- a/test/PublicApi.Tests/PublicApiTests.CosmosDb.DotNet6_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.CosmosDb.DotNet6_0.verified.cs
@@ -31,7 +31,6 @@
     }
     public readonly struct SystemProperty
     {
-        public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _attachments;
         public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _etag;
         public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _rid;
         public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _self;

--- a/test/PublicApi.Tests/PublicApiTests.CosmosDb.DotNet7_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.CosmosDb.DotNet7_0.verified.cs
@@ -31,7 +31,6 @@
     }
     public readonly struct SystemProperty
     {
-        public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _attachments;
         public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _etag;
         public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _rid;
         public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _self;

--- a/test/PublicApi.Tests/PublicApiTests.CosmosDb.DotNet8_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.CosmosDb.DotNet8_0.verified.cs
@@ -31,7 +31,6 @@
     }
     public readonly struct SystemProperty
     {
-        public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _attachments;
         public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _etag;
         public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _rid;
         public static readonly ExRam.Gremlinq.Providers.CosmosDb.SystemProperty _self;


### PR DESCRIPTION
It's not mentioned in https://learn.microsoft.com/en-us/azure/cosmos-db/resource-model.