### PR TITLE
Revert "Bump Testcontainers from 3.8.0 to 3.9.0"

### DIFF
--- a/test/Tests.Fixtures/ExRam.Gremlinq.Tests.Fixtures.csproj
+++ b/test/Tests.Fixtures/ExRam.Gremlinq.Tests.Fixtures.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
     <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
-    <PackageReference Include="Testcontainers" Version="3.9.0" />
+    <PackageReference Include="Testcontainers" Version="3.8.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Too flaky with NullReferenceExceptions.

This reverts commit 21f40add735b02c6cd46fdc2a2b9c36429375847.