### PR TITLE
Reapply "Bump Testcontainers from 3.8.0 to 3.9.0"

### DIFF
--- a/test/Tests.Fixtures/ExRam.Gremlinq.Tests.Fixtures.csproj
+++ b/test/Tests.Fixtures/ExRam.Gremlinq.Tests.Fixtures.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
     <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
-    <PackageReference Include="Testcontainers" Version="3.8.0" />
+    <PackageReference Include="Testcontainers" Version="3.9.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This reverts commit d35935e7ff8d6b79c66ce046632db9eee37a6f03.