### PR TITLE
Include base type in model when it's not abstract.

### DIFF
--- a/src/Core/Models/GraphElementModel.cs
+++ b/src/Core/Models/GraphElementModel.cs
@@ -51,7 +51,7 @@ namespace ExRam.Gremlinq.Core.Models
                                 .Select(static x => x!);
                         }
                     })
-                    .Where(static type => type is { IsNestedPrivate: false, IsClass: true, IsAbstract: false } && type != typeof(TBaseType) && typeof(TBaseType).IsAssignableFrom(type));
+                    .Where(static type => type is { IsNestedPrivate: false, IsClass: true, IsAbstract: false } && typeof(TBaseType).IsAssignableFrom(type));
 
                 foreach (var type in types)
                 {

--- a/test/Core.Tests/Elements/NonAbstractBaseEdge.cs
+++ b/test/Core.Tests/Elements/NonAbstractBaseEdge.cs
@@ -1,0 +1,7 @@
+﻿namespace ExRam.Gremlinq.Core.Tests
+{
+    public class NonAbstractBaseEdge
+    {
+
+    }
+}

--- a/test/Core.Tests/Elements/NonAbstractBaseVertex.cs
+++ b/test/Core.Tests/Elements/NonAbstractBaseVertex.cs
@@ -1,0 +1,7 @@
+﻿namespace ExRam.Gremlinq.Core.Tests
+{
+    public class NonAbstractBaseVertex
+    {
+
+    }
+}

--- a/test/Core.Tests/GraphModelTest.Non_abstract_base_types_are_included.verified.txt
+++ b/test/Core.Tests/GraphModelTest.Non_abstract_base_types_are_included.verified.txt
@@ -1,0 +1,3 @@
+﻿[
+  NonAbstractBaseVertex
+]

--- a/test/Core.Tests/GraphModelTest.cs
+++ b/test/Core.Tests/GraphModelTest.cs
@@ -378,5 +378,19 @@ namespace ExRam.Gremlinq.Core.Tests
                 .VerticesModel
                 .GetMetadata(typeof(VertexElement).GetProperty(nameof(VertexElement.Id))!));
         }
+
+        [Fact]
+        public async Task Non_abstract_base_types_are_included()
+        {
+            var a = GraphModel
+                .FromBaseTypes<NonAbstractBaseVertex, NonAbstractBaseEdge>()
+                .VerticesModel
+                .TryGetFilterLabels(typeof(NonAbstractBaseVertex), FilterLabelsVerbosity.Maximum);
+
+            await Verify(GraphModel
+                .FromBaseTypes<NonAbstractBaseVertex, NonAbstractBaseEdge>()
+                .VerticesModel
+                .TryGetFilterLabels(typeof(NonAbstractBaseVertex), FilterLabelsVerbosity.Maximum));
+        }
     }
 }


### PR DESCRIPTION
Fixes #1627.