### PR TITLE
No need for ContainerAttachedGremlinQuerySource. 

### DIFF
--- a/test/Tests.Fixtures/TestContainerFixture.cs
+++ b/test/Tests.Fixtures/TestContainerFixture.cs
@@ -13,66 +13,6 @@ namespace ExRam.Gremlinq.Tests.Fixtures
 {
     public abstract class TestContainerFixtureBase : GremlinqFixture
     {
-        private sealed class ContainerAttachedGremlinQuerySource : IGremlinQuerySource, IAsyncDisposable
-        {
-            private readonly IContainer _container;
-            private readonly IGremlinQuerySource _baseSource;
-
-            public ContainerAttachedGremlinQuerySource(IContainer container, IGremlinQuerySource baseSource)
-            {
-                _container = container;
-                _baseSource = baseSource;
-            }
-
-            IEdgeGremlinQuery<TEdge> IStartGremlinQuery.AddE<TEdge>(TEdge edge) => _baseSource.AddE(edge);
-
-            IEdgeGremlinQuery<TEdge> IStartGremlinQuery.AddE<TEdge>() => _baseSource.AddE<TEdge>();
-
-            IVertexGremlinQuery<TVertex> IStartGremlinQuery.AddV<TVertex>(TVertex vertex) => _baseSource.AddV(vertex);
-
-            IVertexGremlinQuery<TVertex> IStartGremlinQuery.AddV<TVertex>() => _baseSource.AddV<TVertex>();
-
-            IGremlinQueryAdmin IStartGremlinQuery.AsAdmin() => _baseSource.AsAdmin();
-
-            IGremlinQuerySource IGremlinQuerySource.ConfigureEnvironment(Func<IGremlinQueryEnvironment, IGremlinQueryEnvironment> environmentTransformation) => _baseSource.ConfigureEnvironment(environmentTransformation);
-
-            IEdgeGremlinQuery<object> IStartGremlinQuery.E(object id) => _baseSource.E(id);
-
-            IEdgeGremlinQuery<object> IStartGremlinQuery.E(params object[] ids) => _baseSource.E(ids);
-
-            IEdgeGremlinQuery<TEdge> IStartGremlinQuery.E<TEdge>(object id) => _baseSource.E<TEdge>(id);
-
-            IEdgeGremlinQuery<TEdge> IStartGremlinQuery.E<TEdge>(params object[] ids) => _baseSource.E<TEdge>(ids);
-
-            IGremlinQuery<TElement> IStartGremlinQuery.Inject<TElement>(params TElement[] elements) => _baseSource.Inject(elements);
-
-            IEdgeGremlinQuery<TNewEdge> IStartGremlinQuery.ReplaceE<TNewEdge>(TNewEdge edge) => _baseSource.ReplaceE(edge);
-
-            IVertexGremlinQuery<TNewVertex> IStartGremlinQuery.ReplaceV<TNewVertex>(TNewVertex vertex) => _baseSource.ReplaceV(vertex);
-
-            IVertexGremlinQuery<object> IStartGremlinQuery.V(object id) => _baseSource.V(id);
-
-            IVertexGremlinQuery<object> IStartGremlinQuery.V(params object[] ids) => _baseSource.V(ids);
-
-            IVertexGremlinQuery<TVertex> IStartGremlinQuery.V<TVertex>(object id) => _baseSource.V<TVertex>(id);
-
-            IVertexGremlinQuery<TVertex> IStartGremlinQuery.V<TVertex>(params object[] ids) => _baseSource.V<TVertex>(ids);
-
-            IGremlinQuerySource IGremlinQuerySource.WithSideEffect<TSideEffect>(StepLabel<TSideEffect> label, TSideEffect value) => _baseSource.WithSideEffect(label, value);
-
-            TQuery IGremlinQuerySource.WithSideEffect<TSideEffect, TQuery>(TSideEffect value, Func<IGremlinQuerySource, StepLabel<TSideEffect>, TQuery> continuation) => _baseSource.WithSideEffect(value, continuation);
-
-            IGremlinQuerySource IGremlinQuerySource.ConfigureMetadata(Func<IImmutableDictionary<object, object?>, IImmutableDictionary<object, object?>> metadataTransformation) => _baseSource.ConfigureMetadata(metadataTransformation);
-
-            async ValueTask IAsyncDisposable.DisposeAsync()
-            {
-                await using(_container)
-                {
-                    await _container.StopAsync();
-                }
-            }
-        }
-
         private readonly int _port;
 
         private IContainer? _container;
@@ -85,7 +25,7 @@ namespace ExRam.Gremlinq.Tests.Fixtures
         protected sealed override IGremlinQuerySource TransformQuerySource(IGremlinQuerySource g)
         {
             if (_container is { } container)
-                return TransformQuerySource(_container, new ContainerAttachedGremlinQuerySource(container, g));
+                return TransformQuerySource(container, g);
 
             throw new InvalidOperationException();
         }

--- a/test/Tests.Infrastructure/GremlinqFixture.cs
+++ b/test/Tests.Infrastructure/GremlinqFixture.cs
@@ -23,8 +23,6 @@ namespace ExRam.Gremlinq.Tests.Infrastructure
 
         public virtual async Task DisposeAsync()
         {
-            if (_g is IAsyncDisposable disposable)
-                await disposable.DisposeAsync();
         }
 
         public IGremlinQuerySource G => _g ?? throw new InvalidOperationException();


### PR DESCRIPTION
The container fixtures will dispose of the source.