### PR TITLE
Call logical step flattening outside of And/OrSteps. 

### DIFF
--- a/src/Core/Queries/GremlinQuery.cs
+++ b/src/Core/Queries/GremlinQuery.cs
@@ -204,7 +204,7 @@ namespace ExRam.Gremlinq.Core
                 else
                 {
                     builder = builder
-                        .AddStep(new AndStep(fusedTraversals.ToArray()));
+                        .AddStep(new AndStep(LogicalStep<AndStep>.FlattenLogicalTraversals(fusedTraversals)));
                 }
 
                 return builder
@@ -821,7 +821,7 @@ namespace ExRam.Gremlinq.Core
                     1 => builder.OuterQuery
                         .Where(fusedTraversals[0]),
                     _ => builder
-                        .AddStep(new OrStep(fusedTraversals.ToArray()))
+                        .AddStep(new OrStep(LogicalStep<OrStep>.FlattenLogicalTraversals(fusedTraversals)))
                         .Build()
                 };
             });

--- a/src/Core/Steps/AndStep.cs
+++ b/src/Core/Steps/AndStep.cs
@@ -2,6 +2,7 @@
 {
     public sealed class AndStep : LogicalStep<AndStep>, IFilterStep
     {
+        //TODO: Change to ImmutableArray
         public AndStep(IEnumerable<Traversal> traversals) : base("and", traversals)
         {
         }

--- a/src/Core/Steps/OrStep.cs
+++ b/src/Core/Steps/OrStep.cs
@@ -2,6 +2,7 @@
 {
     public sealed class OrStep : LogicalStep<OrStep>, IFilterStep
     {
+        //TODO: Change to ImmutableArray
         public OrStep(IEnumerable<Traversal> traversals) : base("or", traversals)
         {
         }


### PR DESCRIPTION
This saves a ToArray roundtrip.