### PR TITLE
Update Gremlin.Net

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="Fody" Version="6.8.2" />
 
-    <PackageVersion Include="Gremlin.Net" Version="3.7.2" />
+    <PackageVersion Include="Gremlin.Net" Version="3.7.3" />
 
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.45.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,26 +39,21 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
   </ItemGroup>
 </Project>

--- a/src/Core.AspNet/ExRam.Gremlinq.Core.AspNet.csproj
+++ b/src/Core.AspNet/ExRam.Gremlinq.Core.AspNet.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Support.NewtonsoftJson/Converters/BulkSetConverterFactory.cs
+++ b/src/Support.NewtonsoftJson/Converters/BulkSetConverterFactory.cs
@@ -52,7 +52,7 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
 
         public IConverter<TSource, TTarget>? TryCreate<TSource, TTarget>(IGremlinQueryEnvironment environment)
         {
-            return typeof(TTarget).IsArray && !environment.SupportsType(typeof(TTarget)) && typeof(TSource) == typeof(JObject)
+            return typeof(TSource) == typeof(JObject) && typeof(TTarget).IsArray && !environment.SupportsType(typeof(TTarget))
                 ? (IConverter<TSource, TTarget>?)Activator.CreateInstance(typeof(BulkSetConverter<,>).MakeGenericType(typeof(TTarget), typeof(TTarget).GetElementType()!), environment)
                 : default;
         }


### PR DESCRIPTION
Since Gremlin.Net transitively pulls in Microsoft.Extensions.DependencyInjection.Abstractions now (through an upgrade of Logging to 8.0.0 which has the reference), we get package downgrade errors and remove it from Core.AspNet.