### PR TITLE
Run tests again on .NET 6 and 7 

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(Configuration)' == 'Release'">net8.0;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Configuration)' == 'Release'">net6.0;net7.0;net8.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
...since the API snapshots are present, the frameworks are being installed by the action script and it's a sensible thing to do.