### PR TITLE
No need to reference Microsoft.SourceLink.GitHub for target frameworks >= .NET 8.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -38,7 +38,8 @@
   <ItemGroup Condition="'$(Configuration)' == 'Release'" >
     <None Include="$(PackageLicenseDirectory)$(PackageLicenseFile)" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+   
+   <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'" Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 In fact, it seems to break sourcelink.