### PR TITLE
Revert "Bring back integration tests for JanusGraph on CI."

### DIFF
--- a/test/Providers.JanusGraph.Tests/IntegrationTests.cs
+++ b/test/Providers.JanusGraph.Tests/IntegrationTests.cs
@@ -5,7 +5,7 @@ using ExRam.Gremlinq.Tests.Infrastructure;
 
 namespace ExRam.Gremlinq.Providers.JanusGraph.Tests
 {
-    [IntegrationTest("Linux", true)]
+    [IntegrationTest("Linux")]
     [IntegrationTest("Windows")]
     public class IntegrationTests : QueryExecutionTest, IClassFixture<JanusGraphContainerFixture>
     {


### PR DESCRIPTION
This reverts commit c8eba31c610cb8df65b524d6b566bf419fd342ae.