### PR TITLE
Deprecate the weakly typed overload of As

### DIFF
--- a/src/Core/Queries/Interfaces/IGremlinQuery.cs
+++ b/src/Core/Queries/Interfaces/IGremlinQuery.cs
@@ -88,6 +88,7 @@ namespace ExRam.Gremlinq.Core
     {
         TSelf And(params Func<TSelf, IGremlinQueryBase>[] andTraversals);
 
+        [Obsolete("Deprecated. If the strongly typed overload of As is not in scope, call Cast<object>() before As(...).")]
         TTargetQuery As<TTargetQuery>(Func<TSelf, StepLabel<TSelf, object>, TTargetQuery> continuation) where TTargetQuery : IGremlinQueryBase;
 
         TSelf Coin(double probability);

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet6_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet6_0.verified.cs
@@ -448,6 +448,8 @@
         where TSelf : ExRam.Gremlinq.Core.IGremlinQueryBaseRec<TSelf>
     {
         TSelf And(params System.Func<TSelf, ExRam.Gremlinq.Core.IGremlinQueryBase>[] andTraversals);
+        [System.Obsolete("Deprecated. If the strongly typed overload of As is not in scope, call Cast<objec" +
+            "t>() before As(...).")]
         TTargetQuery As<TTargetQuery>(System.Func<TSelf, ExRam.Gremlinq.Core.StepLabel<TSelf, object>, TTargetQuery> continuation)
             where TTargetQuery : ExRam.Gremlinq.Core.IGremlinQueryBase;
         TSelf Barrier();

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet7_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet7_0.verified.cs
@@ -448,6 +448,8 @@
         where TSelf : ExRam.Gremlinq.Core.IGremlinQueryBaseRec<TSelf>
     {
         TSelf And(params System.Func<TSelf, ExRam.Gremlinq.Core.IGremlinQueryBase>[] andTraversals);
+        [System.Obsolete("Deprecated. If the strongly typed overload of As is not in scope, call Cast<objec" +
+            "t>() before As(...).")]
         TTargetQuery As<TTargetQuery>(System.Func<TSelf, ExRam.Gremlinq.Core.StepLabel<TSelf, object>, TTargetQuery> continuation)
             where TTargetQuery : ExRam.Gremlinq.Core.IGremlinQueryBase;
         TSelf Barrier();

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet8_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet8_0.verified.cs
@@ -448,6 +448,8 @@
         where TSelf : ExRam.Gremlinq.Core.IGremlinQueryBaseRec<TSelf>
     {
         TSelf And(params System.Func<TSelf, ExRam.Gremlinq.Core.IGremlinQueryBase>[] andTraversals);
+        [System.Obsolete("Deprecated. If the strongly typed overload of As is not in scope, call Cast<objec" +
+            "t>() before As(...).")]
         TTargetQuery As<TTargetQuery>(System.Func<TSelf, ExRam.Gremlinq.Core.StepLabel<TSelf, object>, TTargetQuery> continuation)
             where TTargetQuery : ExRam.Gremlinq.Core.IGremlinQueryBase;
         TSelf Barrier();

--- a/test/PublicApi.Tests/PublicApiTests.Core.DotNet9_0.verified.cs
+++ b/test/PublicApi.Tests/PublicApiTests.Core.DotNet9_0.verified.cs
@@ -448,6 +448,8 @@
         where TSelf : ExRam.Gremlinq.Core.IGremlinQueryBaseRec<TSelf>
     {
         TSelf And(params System.Func<TSelf, ExRam.Gremlinq.Core.IGremlinQueryBase>[] andTraversals);
+        [System.Obsolete("Deprecated. If the strongly typed overload of As is not in scope, call Cast<objec" +
+            "t>() before As(...).")]
         TTargetQuery As<TTargetQuery>(System.Func<TSelf, ExRam.Gremlinq.Core.StepLabel<TSelf, object>, TTargetQuery> continuation)
             where TTargetQuery : ExRam.Gremlinq.Core.IGremlinQueryBase;
         TSelf Barrier();


### PR DESCRIPTION
Having both, the strongly typed and the object-typed, in scope leads to a quick exponential growth in overload resolution complexity. To understand why this happens, see https://blog.hediet.de/post/how-to-stress-the-csharp-compiler.