### PR TITLE
Revert "Bump Testcontainers from 4.1.0 to 4.2.0"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="System.Interactive.Async" Version="6.0.1" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="System.Text.Json" Version="9.0.1" />
-    <PackageVersion Include="Testcontainers" Version="4.2.0" />
+    <PackageVersion Include="Testcontainers" Version="4.1.0" />
     <PackageVersion Include="Verify.XunitV3" Version="28.8.1" />
     <PackageVersion Include="Verify.MicrosoftLogging" Version="4.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />


### PR DESCRIPTION
This reverts commit 016353ae0a20c2dc7a313a30858e9674ba977b9e.

With Testcontainers 4.2.0, test fail erratically but in majority with errors like [this](https://github.com/Gremlinq/ExRam.Gremlinq/actions/runs/13450836689/job/37584867356?pr=1895#step:5:490).