### PR TITLE
Support C# 14

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <NoWarn>$(NoWarn);IDE1006;IDE0063;CS1998</NoWarn>
     <Nullable>enable</Nullable>
     <Authors>Daniel Weber</Authors>

--- a/src/Core/Extensions/ExpressionExtensions.cs
+++ b/src/Core/Extensions/ExpressionExtensions.cs
@@ -28,6 +28,11 @@ namespace ExRam.Gremlinq.Core
                         expression = objectExpression;
                         break;
                     }
+                    case MethodCallExpression { Object: null, Method: { DeclaringType: { } declaringType } method, Arguments: [{ } singleArgument] } when declaringType.IsSpanType() && method is { IsSpecialName: true, Name: "op_Implicit" or "op_Explicit" }:
+                    {
+                        expression = singleArgument;
+                        break;
+                    }
                     default:
                     {
                         return expression;
@@ -269,7 +274,21 @@ namespace ExRam.Gremlinq.Core
                                 secondArgument);
                         }
                     }
-                    
+                    else if (methodInfo.IsGenericMethod && methodInfo.DeclaringType == typeof(MemoryExtensions) && methodInfo.Name == nameof(MemoryExtensions.Contains))
+                    {
+                        if (staticMethodCallExpression.Arguments is [_, var secondArgument, ..])
+                        {
+                            if (staticMethodCallExpression.Arguments is [_, _] || (staticMethodCallExpression.Arguments is [_, _, var thirdArgument] && thirdArgument.Strip() is ConstantExpression { Value: null }))
+                            {
+                                return new WhereExpression(
+                                    firstArgument,
+                                    ContainsExpressionSemantics.Instance,
+                                    secondArgument);
+                            }
+                        }
+                    }
+
+
                     break;
                 }
             }

--- a/src/Core/Extensions/TypeExtensions.cs
+++ b/src/Core/Extensions/TypeExtensions.cs
@@ -22,5 +22,7 @@ namespace ExRam.Gremlinq.Core
                 .SelectMany(static type => type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
                 .Where(static p => p.GetMethod is { } getMethod && getMethod.GetBaseDefinition() == getMethod);
         }
+
+        public static bool IsSpanType(this Type type) => type.IsGenericType && type.GetGenericTypeDefinition() is { } genericTypeDefinition && (genericTypeDefinition == typeof(ReadOnlySpan<>) || genericTypeDefinition == typeof(Span<>));
     }
 }


### PR DESCRIPTION
C# 14 binds to different methods because it has a first-class-notion of Span types now. E.g. Contains used to bind to Enumerable.Contains but now binds to MemoryExtensions.Contains. We will have to reconsider recognizing methods that look like Contains.