### PR TITLE
Add a Roslyn analyzer that points out missing null checks on publicly facing reference-type parameters.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="[7.2.1]" />
-    <PackageVersion Include="Fody" Version="6.9.3" />
     <PackageVersion Include="Gremlin.Net" Version="3.7.5" />
 
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.57.1" />
@@ -16,7 +15,6 @@
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="RuntimeNullables.Fody" Version="2.1.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.8" />
     <PackageVersion Include="System.Interactive.Async" Version="7.0.0" />

--- a/ExRam.Gremlinq.slnx
+++ b/ExRam.Gremlinq.slnx
@@ -29,6 +29,7 @@
     <Project Path="test/Tests.Fixtures/ExRam.Gremlinq.Tests.Fixtures.csproj" />
     <Project Path="test/Tests.Infrastructure/ExRam.Gremlinq.Tests.Infrastructure.csproj" />
   </Folder>
+  <Project Path="src/Analyzers/ExRam.Gremlinq.Analyzers.csproj" />
   <Project Path="src/Core.AspNet/ExRam.Gremlinq.Core.AspNet.csproj" />
   <Project Path="src/Core/ExRam.Gremlinq.Core.csproj" />
   <Project Path="src/Providers.Core/ExRam.Gremlinq.Providers.Core.csproj" />

--- a/src/Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,8 @@
+; Unshipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+GQ0001 | Reliability | Warning | NullCheckAnalyzer

--- a/src/Analyzers/ExRam.Gremlinq.Analyzers.csproj
+++ b/src/Analyzers/ExRam.Gremlinq.Analyzers.csproj
@@ -11,4 +11,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
 </Project>

--- a/src/Analyzers/ExRam.Gremlinq.Analyzers.csproj
+++ b/src/Analyzers/ExRam.Gremlinq.Analyzers.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/src/Analyzers/NullCheckAnalyzer.cs
+++ b/src/Analyzers/NullCheckAnalyzer.cs
@@ -1,0 +1,142 @@
+﻿using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ExRam.Gremlinq.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class NullCheckAnalyzer : DiagnosticAnalyzer
+    {
+        public static readonly DiagnosticDescriptor GQ0001 = new DiagnosticDescriptor("GQ0001", "Reference-type parameter lacks null check", "Parameter '{0}' should be checked for null via ArgumentNullException.ThrowIfNull", "Reliability", DiagnosticSeverity.Warning, true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [GQ0001];
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context
+                .ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context
+                .EnableConcurrentExecution();
+
+            context
+                .RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration, SyntaxKind.ConstructorDeclaration);
+        }
+
+        private static void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is BaseMethodDeclarationSyntax methodDeclaration)
+            {
+                if (methodDeclaration.Body != null || methodDeclaration.ExpressionBody != null)
+                {
+                    if (context.SemanticModel.GetDeclaredSymbol(methodDeclaration, context.CancellationToken) is { IsAbstract: false } methodSymbol)
+                    {
+                        if (IsPublicFacingMethod(methodSymbol))
+                            AnalyzeParameters(context, methodSymbol, methodDeclaration.Body, methodDeclaration.ExpressionBody);
+                    }
+                }
+            }
+        }
+
+        private static bool IsPublicFacingMethod(IMethodSymbol method)
+        {
+            if (method.MethodKind == MethodKind.ExplicitInterfaceImplementation)
+            {
+                foreach (var interfaceMethod in method.ExplicitInterfaceImplementations)
+                {
+                    if (interfaceMethod.ContainingType.DeclaredAccessibility == Accessibility.Public)
+                        return true;
+                }
+
+                return false;
+            }
+
+            return method.DeclaredAccessibility == Accessibility.Public && IsPublicOrNestedInPublic(method.ContainingType);
+        }
+
+        private static bool IsPublicOrNestedInPublic(INamedTypeSymbol type)
+        {
+            while (type != null)
+            {
+                if (type.DeclaredAccessibility != Accessibility.Public)
+                    return false;
+
+                type = type.ContainingType;
+            }
+
+            return true;
+        }
+
+        private static void AnalyzeParameters(SyntaxNodeAnalysisContext context, IMethodSymbol method, BlockSyntax? body, ArrowExpressionClauseSyntax? expressionBody)
+        {
+            if (method.Parameters.Length > 0)
+            {
+                var throwIfNullCalls = GetThrowIfNullParameterNames(context, body, expressionBody);
+
+                foreach (var parameter in method.Parameters)
+                {
+                    if (parameter.RefKind != RefKind.Out)
+                    {
+                        if (IsNullableReferenceType(parameter))
+                        {
+                            if (!throwIfNullCalls.Contains(parameter.Name))
+                                context.ReportDiagnostic(Diagnostic.Create(GQ0001, parameter.Locations.Length > 0 ? parameter.Locations[0] : method.Locations[0], parameter.Name));
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool IsNullableReferenceType(IParameterSymbol parameter)
+        {
+            var type = parameter.Type;
+
+            if (type.TypeKind == TypeKind.TypeParameter)
+            {
+                var typeParam = (ITypeParameterSymbol)type;
+
+                return !typeParam.HasValueTypeConstraint && (typeParam.HasNotNullConstraint || typeParam.HasReferenceTypeConstraint);
+            }
+
+            return !type.IsValueType && parameter.NullableAnnotation != NullableAnnotation.Annotated;
+        }
+
+        private static HashSet<string> GetThrowIfNullParameterNames(SyntaxNodeAnalysisContext context, BlockSyntax? body, ArrowExpressionClauseSyntax? expressionBody)
+        {
+            var set = new HashSet<string>(StringComparer.Ordinal);
+
+            if (((SyntaxNode?)body ?? expressionBody) is { } nodeToSearch)
+            {
+                foreach (var invocation in nodeToSearch.DescendantNodes().OfType<InvocationExpressionSyntax>())
+                {
+                    if (IsThrowIfNullCall(invocation, context.SemanticModel, context.CancellationToken))
+                    {
+                        var arguments = invocation.ArgumentList.Arguments;
+
+                        if (arguments.Count >= 1 && arguments[0].Expression is IdentifierNameSyntax identifier)
+                            set.Add(identifier.Identifier.Text);
+                    }
+                }
+            }
+
+            return set;
+        }
+
+        private static bool IsThrowIfNullCall(InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+            {
+                if (memberAccess.Name.Identifier.Text != "ThrowIfNull")
+                    return false;
+
+                if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is IMethodSymbol { ContainingType: { Name: "ArgumentNullException" } containingType } && containingType.ContainingNamespace?.ToDisplayString() == "System")
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Core.AspNet/ConfigurationSection/GremlinqConfigurationSection.cs
+++ b/src/Core.AspNet/ConfigurationSection/GremlinqConfigurationSection.cs
@@ -21,7 +21,12 @@ namespace ExRam.Gremlinq.Core.AspNet
 
         IChangeToken IConfiguration.GetReloadToken() => _baseSection.GetReloadToken();
 
-        IConfigurationSection IConfiguration.GetSection(string key) => _baseSection.GetSection(key);
+        IConfigurationSection IConfiguration.GetSection(string key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return _baseSection.GetSection(key);
+        }
 
         string? IConfiguration.this[string key]
         {

--- a/src/Core.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
+++ b/src/Core.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
@@ -85,25 +85,33 @@ namespace ExRam.Gremlinq.Core.AspNet
                 });
         }
 
-        public static IGremlinqServicesBuilder ConfigureBase(this IGremlinqServicesBuilder builder) => builder
-            .ConfigureQuerySource((source, section) =>
-            {
-                if (section["Alias"] is { Length: > 0 } alias)
-                {
-                    return source
-                        .ConfigureEnvironment(env => env
-                            .ConfigureOptions(options => options
-                                .SetValue(GremlinqOption.Alias, alias)));
-                }
+        public static IGremlinqServicesBuilder ConfigureBase(this IGremlinqServicesBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
 
-                return source;
-            });
+            return builder
+                .ConfigureQuerySource((source, section) =>
+                {
+                    if (section["Alias"] is { Length: > 0 } alias)
+                    {
+                        return source
+                            .ConfigureEnvironment(env => env
+                                .ConfigureOptions(options => options
+                                    .SetValue(GremlinqOption.Alias, alias)));
+                    }
+
+                    return source;
+                });
+        }
 
         public static IGremlinqServicesBuilder<TConfigurator> UseProvider<TConfigurator>(
             this IGremlinqServicesBuilder setup,
             Func<IGremlinQuerySource, Func<Func<TConfigurator, IGremlinQuerySourceTransformation>, IGremlinQuerySource>> providerChoice)
                 where TConfigurator : IGremlinqConfigurator<TConfigurator>
         {
+            ArgumentNullException.ThrowIfNull(setup);
+            ArgumentNullException.ThrowIfNull(providerChoice);
+
             setup.Services
                 .AddTransient<IGremlinQuerySourceTransformation>(s => new UseProviderGremlinQuerySourceTransformation<TConfigurator>(
                     providerChoice,

--- a/src/Core.AspNet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core.AspNet/Extensions/ServiceCollectionExtensions.cs
@@ -58,6 +58,9 @@ namespace ExRam.Gremlinq.Core.AspNet
 
         public static IServiceCollection AddGremlinq(this IServiceCollection serviceCollection, Action<IGremlinqServicesBuilder> configuration)
         {
+            ArgumentNullException.ThrowIfNull(serviceCollection);
+            ArgumentNullException.ThrowIfNull(configuration);
+
             serviceCollection
                 .TryAddSingleton<IGremlinqConfigurationSection>(s => new GremlinqConfigurationSection(s.GetRequiredService<IConfiguration>()));
 

--- a/src/Core/Elements/Tree.cs
+++ b/src/Core/Elements/Tree.cs
@@ -14,6 +14,8 @@ namespace ExRam.Gremlinq.Core
 
         public Tree(IReadOnlyDictionary<TRoot, TSubTree> inner)
         {
+            ArgumentNullException.ThrowIfNull(inner);
+
             _inner = inner;
         }
 
@@ -25,12 +27,22 @@ namespace ExRam.Gremlinq.Core
 
         public int Count => _inner.Count;
 
-        public bool ContainsKey(TRoot key) => _inner.ContainsKey(key);
+        public bool ContainsKey(TRoot key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return _inner.ContainsKey(key);
+        }
 
         public IEnumerator<KeyValuePair<TRoot, TSubTree>> GetEnumerator() => _inner.GetEnumerator();
 
 #pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
-        public bool TryGetValue(TRoot key, [MaybeNullWhen(false)] out TSubTree value) => _inner.TryGetValue(key, out value);
+        public bool TryGetValue(TRoot key, [MaybeNullWhen(false)] out TSubTree value)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return _inner.TryGetValue(key, out value);
+        }
 #pragma warning restore CS8767
 
         IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_inner).GetEnumerator();
@@ -43,6 +55,8 @@ namespace ExRam.Gremlinq.Core
 
         public Tree(IReadOnlyDictionary<TNode, Tree<TNode>> inner) : base(inner)
         {
+            ArgumentNullException.ThrowIfNull(inner);
+
         }
     }
 }

--- a/src/Core/Environment/GremlinQueryEnvironment.cs
+++ b/src/Core/Environment/GremlinQueryEnvironment.cs
@@ -98,16 +98,52 @@ namespace ExRam.Gremlinq.Core
             DefaultNativeTypes,
             NullLogger.Instance);
 
-        public static IGremlinQueryEnvironment UseModel(this IGremlinQueryEnvironment source, IGraphModel model) => source.ConfigureModel(_ => model);
+        public static IGremlinQueryEnvironment UseModel(this IGremlinQueryEnvironment source, IGraphModel model)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(model);
 
-        public static IGremlinQueryEnvironment UseLogger(this IGremlinQueryEnvironment source, ILogger logger) => source.ConfigureLogger(_ => logger);
+            return source.ConfigureModel(_ => model);
+        }
 
-        public static IGremlinQueryEnvironment UseSerializer(this IGremlinQueryEnvironment environment, ITransformer serializer) => environment.ConfigureSerializer(_ => serializer);
+        public static IGremlinQueryEnvironment UseLogger(this IGremlinQueryEnvironment source, ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(logger);
 
-        public static IGremlinQueryEnvironment UseDeserializer(this IGremlinQueryEnvironment environment, ITransformer deserializer) => environment.ConfigureDeserializer(_ => deserializer);
+            return source.ConfigureLogger(_ => logger);
+        }
 
-        public static IGremlinQueryEnvironment UseExecutor(this IGremlinQueryEnvironment environment, IGremlinQueryExecutor executor) => environment.ConfigureExecutor(_ => executor);
+        public static IGremlinQueryEnvironment UseSerializer(this IGremlinQueryEnvironment environment, ITransformer serializer)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(serializer);
 
-        public static IGremlinQueryEnvironment UseDebugger(this IGremlinQueryEnvironment environment, IGremlinQueryDebugger debugger) => environment.ConfigureDebugger(_ => debugger);
+            return environment.ConfigureSerializer(_ => serializer);
+        }
+
+        public static IGremlinQueryEnvironment UseDeserializer(this IGremlinQueryEnvironment environment, ITransformer deserializer)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(deserializer);
+
+            return environment.ConfigureDeserializer(_ => deserializer);
+        }
+
+        public static IGremlinQueryEnvironment UseExecutor(this IGremlinQueryEnvironment environment, IGremlinQueryExecutor executor)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(executor);
+
+            return environment.ConfigureExecutor(_ => executor);
+        }
+
+        public static IGremlinQueryEnvironment UseDebugger(this IGremlinQueryEnvironment environment, IGremlinQueryDebugger debugger)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(debugger);
+
+            return environment.ConfigureDebugger(_ => debugger);
+        }
     }
 }

--- a/src/Core/Execution/GremlinQueryExecutionContext.cs
+++ b/src/Core/Execution/GremlinQueryExecutionContext.cs
@@ -15,12 +15,22 @@ namespace ExRam.Gremlinq.Core.Execution
 
         public GremlinQueryExecutionContext WithNewExecutionId() => new(Query, Guid.NewGuid());
 
-        public GremlinQueryExecutionContext TransformQuery(Func<IGremlinQueryBase, IGremlinQueryBase> transformation) => new(transformation(Query), ExecutionId);
+        public GremlinQueryExecutionContext TransformQuery(Func<IGremlinQueryBase, IGremlinQueryBase> transformation)
+        {
+            ArgumentNullException.ThrowIfNull(transformation);
+
+            return new(transformation(Query), ExecutionId);
+        }
 
         public Guid ExecutionId => _executionId ?? throw UninitializedStruct();
 
         public IGremlinQueryBase Query => _query ?? throw UninitializedStruct();
 
-        public static GremlinQueryExecutionContext Create(IGremlinQueryBase query) => new(query, Guid.NewGuid());
+        public static GremlinQueryExecutionContext Create(IGremlinQueryBase query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return new(query, Guid.NewGuid());
+        }
     }
 }

--- a/src/Core/Execution/GremlinQueryExecutionException.cs
+++ b/src/Core/Execution/GremlinQueryExecutionException.cs
@@ -4,10 +4,15 @@
     {
         public GremlinQueryExecutionException(GremlinQueryExecutionContext executionContext, Exception innerException) : this(executionContext, $"Executing query {executionContext.ExecutionId:D} failed.", innerException)
         {
+            ArgumentNullException.ThrowIfNull(innerException);
+
         }
 
         public GremlinQueryExecutionException(GremlinQueryExecutionContext executionContext, string message, Exception innerException) : base(message, innerException)
         {
+            ArgumentNullException.ThrowIfNull(message);
+            ArgumentNullException.ThrowIfNull(innerException);
+
             ExecutionContext = executionContext;
         }
 

--- a/src/Core/Execution/GremlinQueryExecutor.cs
+++ b/src/Core/Execution/GremlinQueryExecutor.cs
@@ -124,10 +124,27 @@ namespace ExRam.Gremlinq.Core.Execution
 
         public static readonly IGremlinQueryExecutor Invalid = new InvalidGremlinQueryExecutor();
 
-        public static IGremlinQueryExecutor TransformQuery(this IGremlinQueryExecutor baseExecutor, Func<IGremlinQueryBase, IGremlinQueryBase> transformation) => new TransformQueryGremlinQueryExecutor(baseExecutor, transformation);
+        public static IGremlinQueryExecutor TransformQuery(this IGremlinQueryExecutor baseExecutor, Func<IGremlinQueryBase, IGremlinQueryBase> transformation)
+        {
+            ArgumentNullException.ThrowIfNull(baseExecutor);
+            ArgumentNullException.ThrowIfNull(transformation);
 
-        public static IGremlinQueryExecutor TransformExecutionException(this IGremlinQueryExecutor executor, Func<GremlinQueryExecutionException, GremlinQueryExecutionException> exceptionTransformation) => new TransformExecutionExceptionGremlinQueryExecutor(executor, exceptionTransformation);
+            return new TransformQueryGremlinQueryExecutor(baseExecutor, transformation);
+        }
 
-        public static IGremlinQueryExecutor Serialize(this IGremlinQueryExecutor executor) => new SerializingGremlinQueryExecutor(executor);
+        public static IGremlinQueryExecutor TransformExecutionException(this IGremlinQueryExecutor executor, Func<GremlinQueryExecutionException, GremlinQueryExecutionException> exceptionTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(executor);
+            ArgumentNullException.ThrowIfNull(exceptionTransformation);
+
+            return new TransformExecutionExceptionGremlinQueryExecutor(executor, exceptionTransformation);
+        }
+
+        public static IGremlinQueryExecutor Serialize(this IGremlinQueryExecutor executor)
+        {
+            ArgumentNullException.ThrowIfNull(executor);
+
+            return new SerializingGremlinQueryExecutor(executor);
+        }
     }
 }

--- a/src/Core/ExpressionParsing/ExpressionNotSupportedException.cs
+++ b/src/Core/ExpressionParsing/ExpressionNotSupportedException.cs
@@ -8,21 +8,26 @@ namespace ExRam.Gremlinq.Core
 
         public ExpressionNotSupportedException(Expression expression) : base($"The expression '{expression}' is not supported.")
         {
+            ArgumentNullException.ThrowIfNull(expression);
 
         }
 
         public ExpressionNotSupportedException(Expression expression, Exception innerException) : base($"The expression '{expression}' is not supported.", Unwrap(innerException))
         {
+            ArgumentNullException.ThrowIfNull(expression);
+            ArgumentNullException.ThrowIfNull(innerException);
 
         }
 
         public ExpressionNotSupportedException(Exception innerException) : base(StandardMessage, Unwrap(innerException))
         {
+            ArgumentNullException.ThrowIfNull(innerException);
 
         }
 
         public ExpressionNotSupportedException(string message) : base(message)
         {
+            ArgumentNullException.ThrowIfNull(message);
 
         }
 

--- a/src/Core/ExpressionParsing/PFactory/PFactory.cs
+++ b/src/Core/ExpressionParsing/PFactory/PFactory.cs
@@ -157,7 +157,13 @@ namespace ExRam.Gremlinq.Core.ExpressionParsing
 
         public static readonly IPFactory Default = new DefaultPFactory();
 
-        public static IPFactory Override(this IPFactory originalFactory, IPFactory overrideFactory) => new OverridePFactory(originalFactory, overrideFactory);
+        public static IPFactory Override(this IPFactory originalFactory, IPFactory overrideFactory)
+        {
+            ArgumentNullException.ThrowIfNull(originalFactory);
+            ArgumentNullException.ThrowIfNull(overrideFactory);
+
+            return new OverridePFactory(originalFactory, overrideFactory);
+        }
 
         public static readonly GremlinqOption<IPFactory> PFactoryOption = GremlinqOption.Create(Default);
     }

--- a/src/Core/Extensions/BytecodeExtensions.cs
+++ b/src/Core/Extensions/BytecodeExtensions.cs
@@ -6,6 +6,12 @@ namespace ExRam.Gremlinq.Core
 {
     public static class BytecodeExtensions
     {
-        public static GroovyGremlinScript ToGroovyScript(this Bytecode bytecode, IGremlinQueryEnvironment environment, bool includeBindings = true) => GroovyWriter.ToGroovyScript(bytecode, environment, includeBindings);
+        public static GroovyGremlinScript ToGroovyScript(this Bytecode bytecode, IGremlinQueryEnvironment environment, bool includeBindings = true)
+        {
+            ArgumentNullException.ThrowIfNull(bytecode);
+            ArgumentNullException.ThrowIfNull(environment);
+
+            return GroovyWriter.ToGroovyScript(bytecode, environment, includeBindings);
+        }
     }
 }

--- a/src/Core/Extensions/DateGremlinQueryExtensions.cs
+++ b/src/Core/Extensions/DateGremlinQueryExtensions.cs
@@ -2,19 +2,35 @@
 {
     public static class DateGremlinQueryExtensions
     {
-        public static IDateGremlinQuery<DateTimeOffset> Add(this IGremlinQueryBase<DateTimeOffset> query, TimeSpan duration) => query
-            .AsAdmin()
-            .ChangeQueryType<IDateGremlinQuery<DateTimeOffset>>()
-            .Add(duration);
+        public static IDateGremlinQuery<DateTimeOffset> Add(this IGremlinQueryBase<DateTimeOffset> query, TimeSpan duration)
+        {
+            ArgumentNullException.ThrowIfNull(query);
 
-        public static IGremlinQuery<long> Diff(this IGremlinQueryBase<DateTimeOffset> query, DateTimeOffset other) => query
-            .AsAdmin()
-            .ChangeQueryType<IDateGremlinQuery<DateTimeOffset>>()
-            .Diff(other);
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IDateGremlinQuery<DateTimeOffset>>()
+                .Add(duration);
+        }
 
-        public static IGremlinQuery<long> Diff(this IGremlinQueryBase<DateTimeOffset> query, Func<IDateGremlinQuery<DateTimeOffset>, IGremlinQueryBase<DateTimeOffset>> other) => query
-            .AsAdmin()
-            .ChangeQueryType<IDateGremlinQuery<DateTimeOffset>>()
-            .Diff(other);
+        public static IGremlinQuery<long> Diff(this IGremlinQueryBase<DateTimeOffset> query, DateTimeOffset other)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IDateGremlinQuery<DateTimeOffset>>()
+                .Diff(other);
+        }
+
+        public static IGremlinQuery<long> Diff(this IGremlinQueryBase<DateTimeOffset> query, Func<IDateGremlinQuery<DateTimeOffset>, IGremlinQueryBase<DateTimeOffset>> other)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            ArgumentNullException.ThrowIfNull(other);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IDateGremlinQuery<DateTimeOffset>>()
+                .Diff(other);
+        }
     }
 }

--- a/src/Core/Extensions/FeatureSetExtensions.cs
+++ b/src/Core/Extensions/FeatureSetExtensions.cs
@@ -2,16 +2,46 @@
 {
     public static class FeatureSetExtensions
     {
-        public static bool Supports(this IFeatureSet featureSet, GraphFeatures graphFeatures) => (featureSet.GraphFeatures & graphFeatures) == graphFeatures;
+        public static bool Supports(this IFeatureSet featureSet, GraphFeatures graphFeatures)
+        {
+            ArgumentNullException.ThrowIfNull(featureSet);
 
-        public static bool Supports(this IFeatureSet featureSet, VariableFeatures variableFeatures) => (featureSet.VariableFeatures & variableFeatures) == variableFeatures;
+            return (featureSet.GraphFeatures & graphFeatures) == graphFeatures;
+        }
 
-        public static bool Supports(this IFeatureSet featureSet, VertexFeatures vertexFeatures) => (featureSet.VertexFeatures & vertexFeatures) == vertexFeatures;
+        public static bool Supports(this IFeatureSet featureSet, VariableFeatures variableFeatures)
+        {
+            ArgumentNullException.ThrowIfNull(featureSet);
 
-        public static bool Supports(this IFeatureSet featureSet, VertexPropertyFeatures vertexPropertyFeatures) => (featureSet.VertexPropertyFeatures & vertexPropertyFeatures) == vertexPropertyFeatures;
+            return (featureSet.VariableFeatures & variableFeatures) == variableFeatures;
+        }
 
-        public static bool Supports(this IFeatureSet featureSet, EdgeFeatures edgeFeatures) => (featureSet.EdgeFeatures & edgeFeatures) == edgeFeatures;
+        public static bool Supports(this IFeatureSet featureSet, VertexFeatures vertexFeatures)
+        {
+            ArgumentNullException.ThrowIfNull(featureSet);
 
-        public static bool Supports(this IFeatureSet featureSet, EdgePropertyFeatures edgePropertyFeatures) => (featureSet.EdgePropertyFeatures & edgePropertyFeatures) == edgePropertyFeatures;
+            return (featureSet.VertexFeatures & vertexFeatures) == vertexFeatures;
+        }
+
+        public static bool Supports(this IFeatureSet featureSet, VertexPropertyFeatures vertexPropertyFeatures)
+        {
+            ArgumentNullException.ThrowIfNull(featureSet);
+
+            return (featureSet.VertexPropertyFeatures & vertexPropertyFeatures) == vertexPropertyFeatures;
+        }
+
+        public static bool Supports(this IFeatureSet featureSet, EdgeFeatures edgeFeatures)
+        {
+            ArgumentNullException.ThrowIfNull(featureSet);
+
+            return (featureSet.EdgeFeatures & edgeFeatures) == edgeFeatures;
+        }
+
+        public static bool Supports(this IFeatureSet featureSet, EdgePropertyFeatures edgePropertyFeatures)
+        {
+            ArgumentNullException.ThrowIfNull(featureSet);
+
+            return (featureSet.EdgePropertyFeatures & edgePropertyFeatures) == edgePropertyFeatures;
+        }
     }
 }

--- a/src/Core/Extensions/GremlinQueryAdminExtensions.cs
+++ b/src/Core/Extensions/GremlinQueryAdminExtensions.cs
@@ -7,6 +7,9 @@ namespace ExRam.Gremlinq.Core
         public static TTargetQuery AddSteps<TTargetQuery>(this IGremlinQueryAdmin admin, IEnumerable<Step> steps)
             where TTargetQuery : IGremlinQueryBase
         {
+            ArgumentNullException.ThrowIfNull(admin);
+            ArgumentNullException.ThrowIfNull(steps);
+
             var ret = default(IGremlinQueryBase?);
 
             foreach (var step in steps)

--- a/src/Core/Extensions/GremlinQueryEnvironmentExtensions.cs
+++ b/src/Core/Extensions/GremlinQueryEnvironmentExtensions.cs
@@ -4,6 +4,9 @@
     {
         public static bool SupportsType(this IGremlinQueryEnvironment environment, Type type)
         {
+            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(type);
+
             if (environment.SupportsTypeNatively(type))
                 return true;
 
@@ -16,6 +19,12 @@
             return false;
         }
 
-        public static bool SupportsTypeNatively(this IGremlinQueryEnvironment environment, Type type) => environment.NativeTypes.Contains(type);
+        public static bool SupportsTypeNatively(this IGremlinQueryEnvironment environment, Type type)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(type);
+
+            return environment.NativeTypes.Contains(type);
+        }
     }
 }

--- a/src/Core/Extensions/GremlinQueryExtensions.cs
+++ b/src/Core/Extensions/GremlinQueryExtensions.cs
@@ -8,51 +8,86 @@ namespace ExRam.Gremlinq.Core
     {
         private static readonly LimitStep LimitGlobal2 = new(2, Scope.Global);
 
-        public static ValueTask<TElement[]> ToArrayAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default) => query
-            .ToAsyncEnumerable()
-            .ToArrayAsync(ct);
+        public static ValueTask<TElement[]> ToArrayAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
 
-        public static ValueTask<TElement> FirstAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default) => query
-            .AsAdmin()
-            .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
-                .Push(LimitStep.LimitGlobal1))
-            .ToAsyncEnumerable()
-            .FirstAsync(ct);
+            return query
+                .ToAsyncEnumerable()
+                .ToArrayAsync(ct);
+        }
 
-        public static ValueTask<TElement?> FirstOrDefaultAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default) => query
-            .AsAdmin()
-            .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
-                .Push(LimitStep.LimitGlobal1))
-            .ToAsyncEnumerable()
-            .FirstOrDefaultAsync(ct);
+        public static ValueTask<TElement> FirstAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
 
-        public static ValueTask<TElement> SingleAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default) => query
-            .AsAdmin()
-            .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
-                .Push(LimitGlobal2))
-            .ToAsyncEnumerable()
-            .SingleAsync(ct);
+            return query
+                .AsAdmin()
+                .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
+                    .Push(LimitStep.LimitGlobal1))
+                .ToAsyncEnumerable()
+                .FirstAsync(ct);
+        }
 
-        public static ValueTask<TElement?> SingleOrDefaultAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default) => query
-            .AsAdmin()
-            .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
-                .Push(LimitGlobal2))
-            .ToAsyncEnumerable()
-            .SingleOrDefaultAsync(ct);
+        public static ValueTask<TElement?> FirstOrDefaultAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
 
-        public static ValueTask<TElement> LastAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default) => query
-            .AsAdmin()
-            .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
-                .Push(TailStep.TailGlobal1))
-            .ToAsyncEnumerable()
-            .FirstAsync(ct);
+            return query
+                .AsAdmin()
+                .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
+                    .Push(LimitStep.LimitGlobal1))
+                .ToAsyncEnumerable()
+                .FirstOrDefaultAsync(ct);
+        }
 
-        public static ValueTask<TElement?> LastOrDefaultAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default) => query
-            .AsAdmin()
-            .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
-                .Push(TailStep.TailGlobal1))
-            .ToAsyncEnumerable()
-            .FirstOrDefaultAsync(ct);
+        public static ValueTask<TElement> SingleAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
+                    .Push(LimitGlobal2))
+                .ToAsyncEnumerable()
+                .SingleAsync(ct);
+        }
+
+        public static ValueTask<TElement?> SingleOrDefaultAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
+                    .Push(LimitGlobal2))
+                .ToAsyncEnumerable()
+                .SingleOrDefaultAsync(ct);
+        }
+
+        public static ValueTask<TElement> LastAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
+                    .Push(TailStep.TailGlobal1))
+                .ToAsyncEnumerable()
+                .FirstAsync(ct);
+        }
+
+        public static ValueTask<TElement?> LastOrDefaultAsync<TElement>(this IGremlinQueryBase<TElement> query, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ConfigureSteps<IGremlinQuery<TElement>>(static traversal => traversal
+                    .Push(TailStep.TailGlobal1))
+                .ToAsyncEnumerable()
+                .FirstOrDefaultAsync(ct);
+        }
 
         internal static Traversal ToTraversal(this IGremlinQueryBase query) => query
             .AsAdmin().Steps;

--- a/src/Core/Extensions/StringGremlinQueryExtensions.cs
+++ b/src/Core/Extensions/StringGremlinQueryExtensions.cs
@@ -2,74 +2,148 @@
 {
     public static class StringGremlinQueryExtensions
     {
-        public static IStringGremlinQuery<string> Concat(this IGremlinQueryBase<string> query, params string[] strings) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Concat(strings);
+        public static IStringGremlinQuery<string> Concat(this IGremlinQueryBase<string> query, params string[] strings)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            ArgumentNullException.ThrowIfNull(strings);
 
-        public static IStringGremlinQuery<string> Concat(this IGremlinQueryBase<string> query, params Func<IStringGremlinQuery<string>, IGremlinQueryBase<string>>[] stringTraversals) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Concat(stringTraversals);
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Concat(strings);
+        }
 
-        public static IStringGremlinQuery<string> Concat(this IGremlinQueryBase<string> query, params ReadOnlySpan<Func<IStringGremlinQuery<string>, IGremlinQueryBase<string>>> stringTraversals) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Concat(stringTraversals);
+        public static IStringGremlinQuery<string> Concat(this IGremlinQueryBase<string> query, params Func<IStringGremlinQuery<string>, IGremlinQueryBase<string>>[] stringTraversals)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            ArgumentNullException.ThrowIfNull(stringTraversals);
 
-        public static IGremlinQuery<int> Length(this IGremlinQueryBase<string> query) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Length();
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Concat(stringTraversals);
+        }
 
-        public static IStringGremlinQuery<string> Replace(this IGremlinQueryBase<string> query, string oldValue, string newValue) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Replace(oldValue, newValue);
+        public static IStringGremlinQuery<string> Concat(this IGremlinQueryBase<string> query, params ReadOnlySpan<Func<IStringGremlinQuery<string>, IGremlinQueryBase<string>>> stringTraversals)
+        {
+            ArgumentNullException.ThrowIfNull(query);
 
-        public static IStringGremlinQuery<string> Reverse(this IGremlinQueryBase<string> query) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Reverse();
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Concat(stringTraversals);
+        }
 
-        public static IStringGremlinQuery<string> Substring(this IGremlinQueryBase<string> query, int startIndex) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Substring(startIndex);
+        public static IGremlinQuery<int> Length(this IGremlinQueryBase<string> query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
 
-        public static IStringGremlinQuery<string> Substring(this IGremlinQueryBase<string> query, int startIndex, int length) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Substring(startIndex, length);
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Length();
+        }
 
-        public static IStringGremlinQuery<string> Substring(this IGremlinQueryBase<string> query, Range range) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Substring(range);
+        public static IStringGremlinQuery<string> Replace(this IGremlinQueryBase<string> query, string oldValue, string newValue)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            ArgumentNullException.ThrowIfNull(oldValue);
+            ArgumentNullException.ThrowIfNull(newValue);
 
-        public static IStringGremlinQuery<string> ToLower(this IGremlinQueryBase<string> query) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .ToLower();
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Replace(oldValue, newValue);
+        }
 
-        public static IStringGremlinQuery<string> ToUpper(this IGremlinQueryBase<string> query) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .ToUpper();
+        public static IStringGremlinQuery<string> Reverse(this IGremlinQueryBase<string> query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
 
-        public static IStringGremlinQuery<string> Trim(this IGremlinQueryBase<string> query) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .Trim();
-            
-        public static IStringGremlinQuery<string> TrimStart(this IGremlinQueryBase<string> query) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .TrimStart();
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Reverse();
+        }
 
-        public static IStringGremlinQuery<string> TrimEnd(this IGremlinQueryBase<string> query) => query
-            .AsAdmin()
-            .ChangeQueryType<IStringGremlinQuery<string>>()
-            .TrimEnd();
+        public static IStringGremlinQuery<string> Substring(this IGremlinQueryBase<string> query, int startIndex)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Substring(startIndex);
+        }
+
+        public static IStringGremlinQuery<string> Substring(this IGremlinQueryBase<string> query, int startIndex, int length)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Substring(startIndex, length);
+        }
+
+        public static IStringGremlinQuery<string> Substring(this IGremlinQueryBase<string> query, Range range)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Substring(range);
+        }
+
+        public static IStringGremlinQuery<string> ToLower(this IGremlinQueryBase<string> query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .ToLower();
+        }
+
+        public static IStringGremlinQuery<string> ToUpper(this IGremlinQueryBase<string> query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .ToUpper();
+        }
+
+        public static IStringGremlinQuery<string> Trim(this IGremlinQueryBase<string> query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .Trim();
+        }
+
+        public static IStringGremlinQuery<string> TrimStart(this IGremlinQueryBase<string> query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .TrimStart();
+        }
+
+        public static IStringGremlinQuery<string> TrimEnd(this IGremlinQueryBase<string> query)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+
+            return query
+                .AsAdmin()
+                .ChangeQueryType<IStringGremlinQuery<string>>()
+                .TrimEnd();
+        }
     }
 }

--- a/src/Core/Extensions/TransformerClassExtensions.cs
+++ b/src/Core/Extensions/TransformerClassExtensions.cs
@@ -11,15 +11,27 @@ namespace ExRam.Gremlinq.Core
 
             public TryTransformToBuilder(ITransformer transformer)
             {
+                ArgumentNullException.ThrowIfNull(transformer);
+
                 _transformer = transformer;
             }
 
-            public TTarget? From<TSource>(TSource source, IGremlinQueryEnvironment environment) => _transformer.TryTransform<TSource, TTarget>(source, environment, out var value)
-                ? value
-                : null;
+            public TTarget? From<TSource>(TSource source, IGremlinQueryEnvironment environment)
+            {
+                ArgumentNullException.ThrowIfNull(environment);
+
+                return _transformer.TryTransform<TSource, TTarget>(source, environment, out var value)
+                    ? value
+                    : null;
+            }
         }
 
         public static TryTransformToBuilder<TTarget> TryTransformTo<TTarget>(this ITransformer transformer)
-            where TTarget : class => new(transformer);
+            where TTarget : class
+        {
+            ArgumentNullException.ThrowIfNull(transformer);
+
+            return new(transformer);
+        }
     }
 }

--- a/src/Core/Extensions/TransformerExtensions.cs
+++ b/src/Core/Extensions/TransformerExtensions.cs
@@ -10,14 +10,26 @@ namespace ExRam.Gremlinq.Core
 
             public TransformToBuilder(ITransformer transformer)
             {
+                ArgumentNullException.ThrowIfNull(transformer);
+
                 _transformer = transformer;
             }
 
-            public TTarget From<TSource>(TSource source, IGremlinQueryEnvironment environment) => _transformer.TryTransform<TSource, TTarget>(source, environment, out var value)
-                ? value
-                : throw new InvalidCastException($"Cannot convert {source?.GetType() ?? typeof(TSource)} to {typeof(TTarget)}.");
+            public TTarget From<TSource>(TSource source, IGremlinQueryEnvironment environment)
+            {
+                ArgumentNullException.ThrowIfNull(environment);
+
+                return _transformer.TryTransform<TSource, TTarget>(source, environment, out var value)
+                    ? value
+                    : throw new InvalidCastException($"Cannot convert {source?.GetType() ?? typeof(TSource)} to {typeof(TTarget)}.");
+            }
         }
 
-        public static TransformToBuilder<TTarget> TransformTo<TTarget>(this ITransformer transformer) => new(transformer);
+        public static TransformToBuilder<TTarget> TransformTo<TTarget>(this ITransformer transformer)
+        {
+            ArgumentNullException.ThrowIfNull(transformer);
+
+            return new(transformer);
+        }
     }
 }

--- a/src/Core/Extensions/TransformerStructExtensions.cs
+++ b/src/Core/Extensions/TransformerStructExtensions.cs
@@ -11,15 +11,27 @@ namespace ExRam.Gremlinq.Core
 
             public TryTransformToBuilder(ITransformer transformer)
             {
+                ArgumentNullException.ThrowIfNull(transformer);
+
                 _transformer = transformer;
             }
 
-            public TTarget? From<TSource>(TSource source, IGremlinQueryEnvironment environment) => _transformer.TryTransform<TSource, TTarget>(source, environment, out var value)
-                ? value
-                : null;
+            public TTarget? From<TSource>(TSource source, IGremlinQueryEnvironment environment)
+            {
+                ArgumentNullException.ThrowIfNull(environment);
+
+                return _transformer.TryTransform<TSource, TTarget>(source, environment, out var value)
+                    ? value
+                    : null;
+            }
         }
 
         public static TryTransformToBuilder<TTarget> TryTransformTo<TTarget>(this ITransformer transformer)
-            where TTarget : struct => new(transformer);
+            where TTarget : struct
+        {
+            ArgumentNullException.ThrowIfNull(transformer);
+
+            return new(transformer);
+        }
     }
 }

--- a/src/Core/Models/GraphElementModel.cs
+++ b/src/Core/Models/GraphElementModel.cs
@@ -168,23 +168,61 @@ namespace ExRam.Gremlinq.Core.Models
 
         internal static readonly IGraphElementModel Invalid = new InvalidGraphElementModel();
 
-        public static IGraphElementModel UseCamelCaseLabels(this IGraphElementModel model) => model.ConfigureLabels(static (_, proposedLabel) => proposedLabel.ToCamelCase());
+        public static IGraphElementModel UseCamelCaseLabels(this IGraphElementModel model)
+        {
+            ArgumentNullException.ThrowIfNull(model);
 
-        public static IGraphElementModel UseLowerCaseLabels(this IGraphElementModel model) => model.ConfigureLabels(static (_, proposedLabel) => proposedLabel.ToLower());
+            return model.ConfigureLabels(static (_, proposedLabel) => proposedLabel.ToCamelCase());
+        }
 
-        public static IGraphElementModel ConfigureLabels(this IGraphElementModel model, Func<Type, string, string> overrideTransformation) => model.ConfigureMetadata((type, metadata) => new ElementMetadata(overrideTransformation(type, metadata.Label)));
+        public static IGraphElementModel UseLowerCaseLabels(this IGraphElementModel model)
+        {
+            ArgumentNullException.ThrowIfNull(model);
 
-        public static IGraphElementModel ConfigureElement<TElement>(this IGraphElementModel model, Func<IMemberMetadataConfigurator<TElement>, IMemberMetadataConfigurator<TElement>> transformation) => transformation(MemberMetadataConfigurator<TElement>.Identity).Transform(model);
+            return model.ConfigureLabels(static (_, proposedLabel) => proposedLabel.ToLower());
+        }
 
-        public static IGraphElementModel UseCamelCaseMemberNames(this IGraphElementModel model) => model.ConfigureMemberNames(static (_, name) => name.ToCamelCase());
+        public static IGraphElementModel ConfigureLabels(this IGraphElementModel model, Func<Type, string, string> overrideTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(model);
+            ArgumentNullException.ThrowIfNull(overrideTransformation);
 
-        public static IGraphElementModel UseLowerCaseMemberNames(this IGraphElementModel model) => model.ConfigureMemberNames(static (_, name) => name.ToLower());
+            return model.ConfigureMetadata((type, metadata) => new ElementMetadata(overrideTransformation(type, metadata.Label)));
+        }
 
-        public static IGraphElementModel ConfigureMemberNames(this IGraphElementModel model, Func<MemberInfo, string, string> transformation) => model.ConfigureMetadata((member, metadata) => metadata.Key.RawKey is string name
-            ? new MemberMetadata(
-                transformation(member, name),
-                metadata.SerializationBehaviour)
-            : metadata);
+        public static IGraphElementModel ConfigureElement<TElement>(this IGraphElementModel model, Func<IMemberMetadataConfigurator<TElement>, IMemberMetadataConfigurator<TElement>> transformation)
+        {
+            ArgumentNullException.ThrowIfNull(model);
+            ArgumentNullException.ThrowIfNull(transformation);
+
+            return transformation(MemberMetadataConfigurator<TElement>.Identity).Transform(model);
+        }
+
+        public static IGraphElementModel UseCamelCaseMemberNames(this IGraphElementModel model)
+        {
+            ArgumentNullException.ThrowIfNull(model);
+
+            return model.ConfigureMemberNames(static (_, name) => name.ToCamelCase());
+        }
+
+        public static IGraphElementModel UseLowerCaseMemberNames(this IGraphElementModel model)
+        {
+            ArgumentNullException.ThrowIfNull(model);
+
+            return model.ConfigureMemberNames(static (_, name) => name.ToLower());
+        }
+
+        public static IGraphElementModel ConfigureMemberNames(this IGraphElementModel model, Func<MemberInfo, string, string> transformation)
+        {
+            ArgumentNullException.ThrowIfNull(model);
+            ArgumentNullException.ThrowIfNull(transformation);
+
+            return model.ConfigureMetadata((member, metadata) => metadata.Key.RawKey is string name
+                ? new MemberMetadata(
+                    transformation(member, name),
+                    metadata.SerializationBehaviour)
+                : metadata);
+        }
 
         internal static ImmutableArray<string> GetFilterLabels(this IGraphElementModel model, FilterTypes types, FilterLabelsVerbosity verbosity)
         {

--- a/src/Core/Models/GraphModel.cs
+++ b/src/Core/Models/GraphModel.cs
@@ -42,8 +42,14 @@ namespace ExRam.Gremlinq.Core.Models
                 GraphElementModel.FromBaseType<TEdgeBaseType>());
         }
 
-        public static IGraphModel ConfigureElements(this IGraphModel model, Func<IGraphElementModel, IGraphElementModel> transformation) => model
-            .ConfigureVertices(transformation)
-            .ConfigureEdges(transformation);
+        public static IGraphModel ConfigureElements(this IGraphModel model, Func<IGraphElementModel, IGraphElementModel> transformation)
+        {
+            ArgumentNullException.ThrowIfNull(model);
+            ArgumentNullException.ThrowIfNull(transformation);
+
+            return model
+                .ConfigureVertices(transformation)
+                .ConfigureEdges(transformation);
+        }
     }
 }

--- a/src/Core/Models/Metadata/ElementMetadata.cs
+++ b/src/Core/Models/Metadata/ElementMetadata.cs
@@ -8,6 +8,8 @@ namespace ExRam.Gremlinq.Core.Models
 
         public ElementMetadata(string label)
         {
+            ArgumentNullException.ThrowIfNull(label);
+
             _label = label;
         }
 

--- a/src/Core/Models/Metadata/MemberMetadata.cs
+++ b/src/Core/Models/Metadata/MemberMetadata.cs
@@ -16,11 +16,16 @@ namespace ExRam.Gremlinq.Core.Models
 
         public SerializationBehaviour SerializationBehaviour { get; }
 
-        public static MemberMetadata Default(string key) => new ("id".Equals(key, StringComparison.OrdinalIgnoreCase)
-            ? T.Id
-            : "label".Equals(key, StringComparison.OrdinalIgnoreCase)
-                ? T.Label
-                : key);
+        public static MemberMetadata Default(string key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return new ("id".Equals(key, StringComparison.OrdinalIgnoreCase)
+                ? T.Id
+                : "label".Equals(key, StringComparison.OrdinalIgnoreCase)
+                    ? T.Label
+                    : key);
+        }
 
         public bool Equals(MemberMetadata other) => _key == other._key && SerializationBehaviour == other.SerializationBehaviour;
 

--- a/src/Core/Projections/ArrayProjection.cs
+++ b/src/Core/Projections/ArrayProjection.cs
@@ -13,6 +13,8 @@ namespace ExRam.Gremlinq.Core.Projections
 
         public override Traversal ToTraversal(IGremlinQueryEnvironment environment)
         {
+            ArgumentNullException.ThrowIfNull(environment);
+
             var inner = _inner.ToTraversal(environment);
 
             if (inner.Count > 0)

--- a/src/Core/Projections/EdgeProjection.cs
+++ b/src/Core/Projections/EdgeProjection.cs
@@ -2,7 +2,12 @@
 {
     public sealed class EdgeProjection : Projection
     {
-        public override Traversal ToTraversal(IGremlinQueryEnvironment environment) => environment.Options.GetValue(GremlinqOption.EdgeProjectionSteps);
+        public override Traversal ToTraversal(IGremlinQueryEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+
+            return environment.Options.GetValue(GremlinqOption.EdgeProjectionSteps);
+        }
 
         public override Projection Lower() => EdgeOrVertex;
     }

--- a/src/Core/Projections/GroupProjection.cs
+++ b/src/Core/Projections/GroupProjection.cs
@@ -16,6 +16,8 @@ namespace ExRam.Gremlinq.Core.Projections
 
         public override Traversal ToTraversal(IGremlinQueryEnvironment environment)
         {
+            ArgumentNullException.ThrowIfNull(environment);
+
             var keyProjectionTraversal = _keyProjection.ToTraversal(environment);
             var valueProjectionTraversal = _valueProjection.ToTraversal(environment);
 

--- a/src/Core/Projections/Projection.cs
+++ b/src/Core/Projections/Projection.cs
@@ -14,11 +14,22 @@ namespace ExRam.Gremlinq.Core.Projections
 
         internal static readonly EmptyProjection Property = Empty;
 
-        public virtual Traversal ToTraversal(IGremlinQueryEnvironment environment) => Traversal.Empty;
+        public virtual Traversal ToTraversal(IGremlinQueryEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+
+            return Traversal.Empty;
+        }
 
         public ArrayProjection Fold() => new(this);
 
-        public TupleProjection Project(ProjectStep projectStep, ProjectStep.ByStep[] bySteps) => Project(projectStep, bySteps.AsSpan());
+        public TupleProjection Project(ProjectStep projectStep, ProjectStep.ByStep[] bySteps)
+        {
+            ArgumentNullException.ThrowIfNull(projectStep);
+            ArgumentNullException.ThrowIfNull(bySteps);
+
+            return Project(projectStep, bySteps.AsSpan());
+        }
 
         internal TupleProjection Project(ProjectStep projectStep, ReadOnlySpan<ProjectStep.ByStep> bySteps)
         {
@@ -39,7 +50,13 @@ namespace ExRam.Gremlinq.Core.Projections
             return new TupleProjection(tuples);
         }
 
-        public GroupProjection Group(Projection keyProjection, Projection valueProjection) => new(keyProjection, valueProjection);
+        public GroupProjection Group(Projection keyProjection, Projection valueProjection)
+        {
+            ArgumentNullException.ThrowIfNull(keyProjection);
+            ArgumentNullException.ThrowIfNull(valueProjection);
+
+            return new(keyProjection, valueProjection);
+        }
 
         internal Projection If<TProjection>(Func<TProjection, Projection> transformation)
             where TProjection : Projection

--- a/src/Core/Projections/TupleProjection.cs
+++ b/src/Core/Projections/TupleProjection.cs
@@ -28,6 +28,8 @@ namespace ExRam.Gremlinq.Core.Projections
 
         public override Traversal ToTraversal(IGremlinQueryEnvironment environment)
         {
+            ArgumentNullException.ThrowIfNull(environment);
+
             var emptyProjectionProtection = environment.Options.GetValue(GremlinqOption.EnableEmptyProjectionValueProtection)
                 ? environment.Options.GetValue(GremlinqOption.EmptyProjectionProtectionDecoratorSteps)
                 : default(Traversal?);

--- a/src/Core/Projections/VertexProjection.cs
+++ b/src/Core/Projections/VertexProjection.cs
@@ -2,9 +2,14 @@
 {
     public sealed class VertexProjection : Projection
     {
-        public override Traversal ToTraversal(IGremlinQueryEnvironment environment) => environment.Options.GetValue(environment.FeatureSet.Supports(VertexFeatures.MetaProperties)
-            ? GremlinqOption.VertexProjectionSteps
-            : GremlinqOption.VertexProjectionWithoutMetaPropertiesSteps);
+        public override Traversal ToTraversal(IGremlinQueryEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+
+            return environment.Options.GetValue(environment.FeatureSet.Supports(VertexFeatures.MetaProperties)
+                ? GremlinqOption.VertexProjectionSteps
+                : GremlinqOption.VertexProjectionWithoutMetaPropertiesSteps);
+        }
 
         public override Projection Lower() => EdgeOrVertex;
     }

--- a/src/Core/Projections/VertexPropertyProjection.cs
+++ b/src/Core/Projections/VertexPropertyProjection.cs
@@ -2,9 +2,14 @@
 {
     public sealed class VertexPropertyProjection : Projection
     {
-        public override Traversal ToTraversal(IGremlinQueryEnvironment environment) => environment.Options.GetValue(environment.FeatureSet.Supports(VertexFeatures.MetaProperties)
-            ? GremlinqOption.VertexPropertyProjectionSteps
-            : GremlinqOption.VertexPropertyProjectionWithoutMetaPropertiesSteps);
+        public override Traversal ToTraversal(IGremlinQueryEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+
+            return environment.Options.GetValue(environment.FeatureSet.Supports(VertexFeatures.MetaProperties)
+                ? GremlinqOption.VertexPropertyProjectionSteps
+                : GremlinqOption.VertexPropertyProjectionWithoutMetaPropertiesSteps);
+        }
 
         public override Projection Lower() => Element;
     }

--- a/src/Core/Queries/GremlinQuery.GroupBuilder.cs
+++ b/src/Core/Queries/GremlinQuery.GroupBuilder.cs
@@ -26,21 +26,31 @@ namespace ExRam.Gremlinq.Core
                 _valueTraversal = valueTraversal;
             }
 
-            IGroupBuilderWithKey<GremlinQuery<T1, T2, T3, T4>, TNewKey> IGroupBuilder<GremlinQuery<T1, T2, T3, T4>>.ByKey<TNewKey>(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase<TNewKey>> keySelector) => new GroupBuilder<TNewKey, object>(
-                _outerQuery,
-                _outerQuery
-                    .Continue()
-                    .With(keySelector)
-                    .Build(static (_, traversal) => traversal),
-                _valueTraversal);
+            IGroupBuilderWithKey<GremlinQuery<T1, T2, T3, T4>, TNewKey> IGroupBuilder<GremlinQuery<T1, T2, T3, T4>>.ByKey<TNewKey>(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase<TNewKey>> keySelector)
+            {
+                ArgumentNullException.ThrowIfNull(keySelector);
 
-            IGroupBuilderWithKeyAndValue<TKey, TNewValue> IGroupBuilderWithKey<GremlinQuery<T1, T2, T3, T4>, TKey>.ByValue<TNewValue>(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase<TNewValue>> valueSelector) => new GroupBuilder<TKey, TNewValue>(
-                _outerQuery,
-                _keyTraversal,
-                _outerQuery
-                    .Continue()
-                    .With(valueSelector)
-                    .Build(static (_, traversal) => traversal));
+                return new GroupBuilder<TNewKey, object>(
+                    _outerQuery,
+                    _outerQuery
+                        .Continue()
+                        .With(keySelector)
+                        .Build(static (_, traversal) => traversal),
+                    _valueTraversal);
+            }
+
+            IGroupBuilderWithKeyAndValue<TKey, TNewValue> IGroupBuilderWithKey<GremlinQuery<T1, T2, T3, T4>, TKey>.ByValue<TNewValue>(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase<TNewValue>> valueSelector)
+            {
+                ArgumentNullException.ThrowIfNull(valueSelector);
+
+                return new GroupBuilder<TKey, TNewValue>(
+                    _outerQuery,
+                    _keyTraversal,
+                    _outerQuery
+                        .Continue()
+                        .With(valueSelector)
+                        .Build(static (_, traversal) => traversal));
+            }
 
             IMapGremlinQuery<IDictionary<TKey, TValue>> IGroupBuilderWithKeyAndValue<TKey, TValue>.Build() => _outerQuery
                 .Continue()

--- a/src/Core/Queries/GremlinQuery.LoopBuilder.cs
+++ b/src/Core/Queries/GremlinQuery.LoopBuilder.cs
@@ -36,23 +36,63 @@ namespace ExRam.Gremlinq.Core
 
             IUntilRepeatEmitLoopBuilder<TQuery> IUntilRepeatLoopBuilder<TQuery>.Emit() => Emit();
 
-            IEmitRepeatLoopBuilder<TQuery> IEmitLoopBuilder<TQuery>.Repeat(Func<TQuery, TQuery> loop) => Repeat(loop);
+            IEmitRepeatLoopBuilder<TQuery> IEmitLoopBuilder<TQuery>.Repeat(Func<TQuery, TQuery> loop)
+            {
+                ArgumentNullException.ThrowIfNull(loop);
 
-            IUntilRepeatLoopBuilder<TQuery> IUntilLoopBuilder<TQuery>.Repeat(Func<TQuery, TQuery> loop) => Repeat(loop);
+                return Repeat(loop);
+            }
 
-            IUntilEmitRepeatLoopBuilder<TQuery> IUntilEmitLoopBuilder<TQuery>.Repeat(Func<TQuery, TQuery> loop) => Repeat(loop);
+            IUntilRepeatLoopBuilder<TQuery> IUntilLoopBuilder<TQuery>.Repeat(Func<TQuery, TQuery> loop)
+            {
+                ArgumentNullException.ThrowIfNull(loop);
 
-            IEmitRepeatUntilLoopBuilder<TQuery> IEmitRepeatLoopBuilder<TQuery>.Until(Func<TQuery, IGremlinQueryBase> condition) => Until(condition);
+                return Repeat(loop);
+            }
 
-            IRepeatUntilLoopBuilder<TQuery> IRepeatLoopBuilder<TQuery>.Until(Func<TQuery, IGremlinQueryBase> condition) => Until(condition);
+            IUntilEmitRepeatLoopBuilder<TQuery> IUntilEmitLoopBuilder<TQuery>.Repeat(Func<TQuery, TQuery> loop)
+            {
+                ArgumentNullException.ThrowIfNull(loop);
 
-            IRepeatEmitUntilLoopBuilder<TQuery> IRepeatEmitLoopBuilder<TQuery>.Until(Func<TQuery, IGremlinQueryBase> condition) => Until(condition);
+                return Repeat(loop);
+            }
 
-            IRepeatLoopBuilder<TQuery> IStartLoopBuilder<TQuery>.Repeat(Func<TQuery, TQuery> loop) => Repeat(loop);
+            IEmitRepeatUntilLoopBuilder<TQuery> IEmitRepeatLoopBuilder<TQuery>.Until(Func<TQuery, IGremlinQueryBase> condition)
+            {
+                ArgumentNullException.ThrowIfNull(condition);
+
+                return Until(condition);
+            }
+
+            IRepeatUntilLoopBuilder<TQuery> IRepeatLoopBuilder<TQuery>.Until(Func<TQuery, IGremlinQueryBase> condition)
+            {
+                ArgumentNullException.ThrowIfNull(condition);
+
+                return Until(condition);
+            }
+
+            IRepeatEmitUntilLoopBuilder<TQuery> IRepeatEmitLoopBuilder<TQuery>.Until(Func<TQuery, IGremlinQueryBase> condition)
+            {
+                ArgumentNullException.ThrowIfNull(condition);
+
+                return Until(condition);
+            }
+
+            IRepeatLoopBuilder<TQuery> IStartLoopBuilder<TQuery>.Repeat(Func<TQuery, TQuery> loop)
+            {
+                ArgumentNullException.ThrowIfNull(loop);
+
+                return Repeat(loop);
+            }
 
             IEmitLoopBuilder<TQuery> IStartLoopBuilder<TQuery>.Emit() => Emit();
 
-            IUntilLoopBuilder<TQuery> IStartLoopBuilder<TQuery>.Until(Func<TQuery, IGremlinQueryBase> condition) => Until(condition);
+            IUntilLoopBuilder<TQuery> IStartLoopBuilder<TQuery>.Until(Func<TQuery, IGremlinQueryBase> condition)
+            {
+                ArgumentNullException.ThrowIfNull(condition);
+
+                return Until(condition);
+            }
 
             IEmitRepeatUntilLoopBuilder<TQuery> IEmitRepeatLoopBuilder<TQuery>.Times(int loopCount) => Times(loopCount);
 

--- a/src/Core/Queries/GremlinQuery.OrderBuilder.cs
+++ b/src/Core/Queries/GremlinQuery.OrderBuilder.cs
@@ -18,17 +18,47 @@ namespace ExRam.Gremlinq.Core
 
             GremlinQuery<T1, T2, T3, T4> IOrderBuilderWithBy<GremlinQuery<T1, T2, T3, T4>>.Build() => _query;
 
-            IOrderBuilderWithBy<T1, GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<T1, GremlinQuery<T1, T2, T3, T4>>.By(Expression<Func<T1, object?>> projection) => By(projection, Gremlin.Net.Process.Traversal.Order.Asc);
+            IOrderBuilderWithBy<T1, GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<T1, GremlinQuery<T1, T2, T3, T4>>.By(Expression<Func<T1, object?>> projection)
+            {
+                ArgumentNullException.ThrowIfNull(projection);
 
-            IOrderBuilderWithBy<T1, GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<T1, GremlinQuery<T1, T2, T3, T4>>.By(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> traversal) => By(traversal, Gremlin.Net.Process.Traversal.Order.Asc);
+                return By(projection, Gremlin.Net.Process.Traversal.Order.Asc);
+            }
 
-            IOrderBuilderWithBy<GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<GremlinQuery<T1, T2, T3, T4>>.By(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> traversal) => By(traversal, Gremlin.Net.Process.Traversal.Order.Asc);
+            IOrderBuilderWithBy<T1, GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<T1, GremlinQuery<T1, T2, T3, T4>>.By(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> traversal)
+            {
+                ArgumentNullException.ThrowIfNull(traversal);
 
-            IOrderBuilderWithBy<T1, GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<T1, GremlinQuery<T1, T2, T3, T4>>.ByDescending(Expression<Func<T1, object?>> projection) => By(projection, Gremlin.Net.Process.Traversal.Order.Desc);
+                return By(traversal, Gremlin.Net.Process.Traversal.Order.Asc);
+            }
 
-            IOrderBuilderWithBy<T1, GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<T1, GremlinQuery<T1, T2, T3, T4>>.ByDescending(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> traversal) => By(traversal, Gremlin.Net.Process.Traversal.Order.Desc);
+            IOrderBuilderWithBy<GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<GremlinQuery<T1, T2, T3, T4>>.By(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> traversal)
+            {
+                ArgumentNullException.ThrowIfNull(traversal);
 
-            IOrderBuilderWithBy<GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<GremlinQuery<T1, T2, T3, T4>>.ByDescending(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> traversal) => By(traversal, Gremlin.Net.Process.Traversal.Order.Desc);
+                return By(traversal, Gremlin.Net.Process.Traversal.Order.Asc);
+            }
+
+            IOrderBuilderWithBy<T1, GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<T1, GremlinQuery<T1, T2, T3, T4>>.ByDescending(Expression<Func<T1, object?>> projection)
+            {
+                ArgumentNullException.ThrowIfNull(projection);
+
+                return By(projection, Gremlin.Net.Process.Traversal.Order.Desc);
+            }
+
+            IOrderBuilderWithBy<T1, GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<T1, GremlinQuery<T1, T2, T3, T4>>.ByDescending(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> traversal)
+            {
+                ArgumentNullException.ThrowIfNull(traversal);
+
+                return By(traversal, Gremlin.Net.Process.Traversal.Order.Desc);
+            }
+
+            IOrderBuilderWithBy<GremlinQuery<T1, T2, T3, T4>> IOrderBuilder<GremlinQuery<T1, T2, T3, T4>>.ByDescending(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> traversal)
+            {
+                ArgumentNullException.ThrowIfNull(traversal);
+
+                return By(traversal, Gremlin.Net.Process.Traversal.Order.Desc);
+            }
 
             private OrderBuilder By(Expression<Func<T1, object?>> projection, Order order) => new(_query
                 .Continue()

--- a/src/Core/Queries/GremlinQuery.ProjectBuilder.cs
+++ b/src/Core/Queries/GremlinQuery.ProjectBuilder.cs
@@ -64,33 +64,64 @@ namespace ExRam.Gremlinq.Core
             }
 
             IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1> IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1>.By(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> projection)
-                => ByLambda<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(projection);
+            {
+                ArgumentNullException.ThrowIfNull(projection);
+
+                return ByLambda<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(projection);
+            }
 
             IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1> IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1>.By(string name, Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> projection)
-                => ByLambda<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(projection, name);
+            {
+                ArgumentNullException.ThrowIfNull(name);
+                ArgumentNullException.ThrowIfNull(projection);
+
+                return ByLambda<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(projection, name);
+            }
 
             IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1> IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1>.By(string name, Expression<Func<T1, object>> projection)
-                => ByExpression<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(projection, name);
+            {
+                ArgumentNullException.ThrowIfNull(name);
+                ArgumentNullException.ThrowIfNull(projection);
 
-            IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1> IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1>.By(Expression<Func<T1, object>> projection) => projection.IsIdentityExpression()
-                ? ByLambda<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(static __ => __.Identity())
-                : projection.Body.Strip() is MemberExpression memberExpression
-                    ? ByExpression<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(memberExpression, memberExpression.Member.Name)
-                    : throw new ExpressionNotSupportedException(projection);
+                return ByExpression<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(projection, name);
+            }
+
+            IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1> IProjectDynamicBuilder<GremlinQuery<T1, T2, T3, T4>, T1>.By(Expression<Func<T1, object>> projection)
+            {
+                ArgumentNullException.ThrowIfNull(projection);
+
+                return projection.IsIdentityExpression()
+                    ? ByLambda<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(static __ => __.Identity())
+                    : projection.Body.Strip() is MemberExpression memberExpression
+                        ? ByExpression<object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object>(memberExpression, memberExpression.Member.Name)
+                        : throw new ExpressionNotSupportedException(projection);
+            }
 
             IMapGremlinQuery<TItem1> IProjectMapResult<TItem1>.Build() => Build<IMapGremlinQuery<TItem1>>();
 
             IGremlinQuery<dynamic> IProjectDynamicResult.Build() => Build<IGremlinQuery<dynamic>>();
 
-            IProjectMapBuilder<GremlinQuery<T1, T2, T3, T4>, T1, TItem1> IProjectMapBuilder<GremlinQuery<T1, T2, T3, T4>, T1, TItem1>.By<TSourceProperty, TTargetProperty>(Expression<Func<TItem1, TTargetProperty>> targetExpression, Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase<TSourceProperty>> projection) => By(
-                targetExpression,
-                static (@this, memberName, projection) => @this.ByLambda<TItem1, TItem2, TItem3, TItem4, TItem5, TItem6, TItem7, TItem8, TItem9, TItem10, TItem11, TItem12, TItem13, TItem14, TItem15, TItem16>(projection, memberName),
-                projection);
+            IProjectMapBuilder<GremlinQuery<T1, T2, T3, T4>, T1, TItem1> IProjectMapBuilder<GremlinQuery<T1, T2, T3, T4>, T1, TItem1>.By<TSourceProperty, TTargetProperty>(Expression<Func<TItem1, TTargetProperty>> targetExpression, Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase<TSourceProperty>> projection)
+            {
+                ArgumentNullException.ThrowIfNull(targetExpression);
+                ArgumentNullException.ThrowIfNull(projection);
 
-            IProjectMapBuilder<GremlinQuery<T1, T2, T3, T4>, T1, TItem1> IProjectMapBuilder<GremlinQuery<T1, T2, T3, T4>, T1, TItem1>.By<TSourceProperty, TTargetProperty>(Expression<Func<TItem1, TTargetProperty>> targetExpression, Expression<Func<T1, TSourceProperty>> projection) => By(
-                targetExpression,
-                static (@this, memberName, projection) => @this.ByExpression<TItem1, TItem2, TItem3, TItem4, TItem5, TItem6, TItem7, TItem8, TItem9, TItem10, TItem11, TItem12, TItem13, TItem14, TItem15, TItem16>(projection, memberName),
-                projection);
+                return By(
+                    targetExpression,
+                    static (@this, memberName, projection) => @this.ByLambda<TItem1, TItem2, TItem3, TItem4, TItem5, TItem6, TItem7, TItem8, TItem9, TItem10, TItem11, TItem12, TItem13, TItem14, TItem15, TItem16>(projection, memberName),
+                    projection);
+            }
+
+            IProjectMapBuilder<GremlinQuery<T1, T2, T3, T4>, T1, TItem1> IProjectMapBuilder<GremlinQuery<T1, T2, T3, T4>, T1, TItem1>.By<TSourceProperty, TTargetProperty>(Expression<Func<TItem1, TTargetProperty>> targetExpression, Expression<Func<T1, TSourceProperty>> projection)
+            {
+                ArgumentNullException.ThrowIfNull(targetExpression);
+                ArgumentNullException.ThrowIfNull(projection);
+
+                return By(
+                    targetExpression,
+                    static (@this, memberName, projection) => @this.ByExpression<TItem1, TItem2, TItem3, TItem4, TItem5, TItem6, TItem7, TItem8, TItem9, TItem10, TItem11, TItem12, TItem13, TItem14, TItem15, TItem16>(projection, memberName),
+                    projection);
+            }
 
             private ProjectBuilder<TNewItem1, TNewItem2, TNewItem3, TNewItem4, TNewItem5, TNewItem6, TNewItem7, TNewItem8, TNewItem9, TNewItem10, TNewItem11, TNewItem12, TNewItem13, TNewItem14, TNewItem15, TNewItem16> ByLambda<TNewItem1, TNewItem2, TNewItem3, TNewItem4, TNewItem5, TNewItem6, TNewItem7, TNewItem8, TNewItem9, TNewItem10, TNewItem11, TNewItem12, TNewItem13, TNewItem14, TNewItem15, TNewItem16>(Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase> projection, string? name = null) => new(
                 _outer,

--- a/src/Core/Queries/GremlinQuery.explicit.cs
+++ b/src/Core/Queries/GremlinQuery.explicit.cs
@@ -1,4 +1,4 @@
-// ReSharper disable ArrangeThisQualifier
+﻿// ReSharper disable ArrangeThisQualifier
 // ReSharper disable CoVariantArrayConversion
 using System.Collections.Immutable;
 using System.Linq.Expressions;
@@ -60,7 +60,12 @@ namespace ExRam.Gremlinq.Core
 
         IEdgeGremlinQuery<T1> IEdgeGremlinQuery<T1, T2, T3>.Lower() => this;
 
-        IEdgeGremlinQuery<T1, TNewOutVertex, T3> IInEdgeGremlinQueryBase<T1, T3>.From<TNewOutVertex>(Func<IVertexGremlinQuery<T3>, IVertexGremlinQueryBase<TNewOutVertex>> fromVertexTraversal) => From(fromVertexTraversal);
+        IEdgeGremlinQuery<T1, TNewOutVertex, T3> IInEdgeGremlinQueryBase<T1, T3>.From<TNewOutVertex>(Func<IVertexGremlinQuery<T3>, IVertexGremlinQueryBase<TNewOutVertex>> fromVertexTraversal)
+        {
+            ArgumentNullException.ThrowIfNull(fromVertexTraversal);
+
+            return From(fromVertexTraversal);
+        }
 
         IVertexGremlinQuery<T3> IInEdgeGremlinQueryBase<T1, T3>.InV() => InOutV<object, GremlinQuery<T3, object, object, IGremlinQueryBase>>(InVStep.Instance);
 
@@ -70,7 +75,12 @@ namespace ExRam.Gremlinq.Core
 
         IVertexGremlinQuery<T2> IOutEdgeGremlinQueryBase<T1, T2>.OutV() => InOutV<object, GremlinQuery<T2, object, object, IGremlinQueryBase>>(OutVStep.Instance);
 
-        IEdgeGremlinQuery<T1, T2, TNewInVertex> IOutEdgeGremlinQueryBase<T1, T2>.To<TNewInVertex>(Func<IVertexGremlinQuery<T2>, IVertexGremlinQueryBase<TNewInVertex>> toVertexTraversal) => To(toVertexTraversal);
+        IEdgeGremlinQuery<T1, T2, TNewInVertex> IOutEdgeGremlinQueryBase<T1, T2>.To<TNewInVertex>(Func<IVertexGremlinQuery<T2>, IVertexGremlinQueryBase<TNewInVertex>> toVertexTraversal)
+        {
+            ArgumentNullException.ThrowIfNull(toVertexTraversal);
+
+            return To(toVertexTraversal);
+        }
 
         IEdgeGremlinQuery<object> IInEdgeGremlinQueryBase.Lower() => CloneAs<IEdgeGremlinQuery<object>>();
 
@@ -84,11 +94,21 @@ namespace ExRam.Gremlinq.Core
 
         IVertexGremlinQuery<TVertex> IEdgeGremlinQueryBase.BothV<TVertex>() => BothV<TVertex>();
 
-        IOutEdgeGremlinQuery<T1, TNewOutVertex> IEdgeGremlinQueryBase<T1>.From<TNewOutVertex>(StepLabel<TNewOutVertex> stepLabel) => From<T1, TNewOutVertex, T3>(stepLabel);
+        IOutEdgeGremlinQuery<T1, TNewOutVertex> IEdgeGremlinQueryBase<T1>.From<TNewOutVertex>(StepLabel<TNewOutVertex> stepLabel)
+        {
+            ArgumentNullException.ThrowIfNull(stepLabel);
+
+            return From<T1, TNewOutVertex, T3>(stepLabel);
+        }
 
         IEdgeOrVertexGremlinQuery<T1> IEdgeGremlinQueryBase<T1>.Lower() => this;
 
-        IOutEdgeGremlinQuery<T1, TNewOutVertex> IEdgeGremlinQueryBase<T1>.From<TNewOutVertex>(Func<IVertexGremlinQueryBase, IVertexGremlinQueryBase<TNewOutVertex>> fromVertexTraversal) => From<TNewOutVertex, object>(fromVertexTraversal);
+        IOutEdgeGremlinQuery<T1, TNewOutVertex> IEdgeGremlinQueryBase<T1>.From<TNewOutVertex>(Func<IVertexGremlinQueryBase, IVertexGremlinQueryBase<TNewOutVertex>> fromVertexTraversal)
+        {
+            ArgumentNullException.ThrowIfNull(fromVertexTraversal);
+
+            return From<TNewOutVertex, object>(fromVertexTraversal);
+        }
 
         IVertexGremlinQuery<object> IEdgeGremlinQueryBase.InV() => InOutV<object, GremlinQuery<object, object, object, IGremlinQueryBase>>(InVStep.Instance);
 
@@ -102,15 +122,30 @@ namespace ExRam.Gremlinq.Core
 
         IVertexGremlinQuery<TVertex> IEdgeGremlinQueryBase.OutV<TVertex>() => InOutV<TVertex, GremlinQuery<TVertex, object, object, IGremlinQueryBase>>(OutVStep.Instance);
 
-        IPropertyGremlinQuery<Property<TValue>> IEdgeGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, TValue>>[] projections) => Properties<Property<TValue>, TValue, object>(Projection.Property, projections);
+        IPropertyGremlinQuery<Property<TValue>> IEdgeGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, TValue>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return Properties<Property<TValue>, TValue, object>(Projection.Property, projections);
+        }
 
         IPropertyGremlinQuery<Property<TValue>> IEdgeGremlinQueryBase<T1>.Properties<TValue>(params ReadOnlySpan<Expression<Func<T1, TValue>>> projections) => Properties<Property<TValue>, TValue, object>(Projection.Property, projections.Cast().To<LambdaExpression>());
 
-        IPropertyGremlinQuery<Property<TValue>> IEdgeGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, Property<TValue>>>[] projections) => Properties<Property<TValue>, TValue, object>(Projection.Property, projections);
+        IPropertyGremlinQuery<Property<TValue>> IEdgeGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, Property<TValue>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return Properties<Property<TValue>, TValue, object>(Projection.Property, projections);
+        }
 
         IPropertyGremlinQuery<Property<TValue>> IEdgeGremlinQueryBase<T1>.Properties<TValue>(params ReadOnlySpan<Expression<Func<T1, Property<TValue>>>> projections) => Properties<Property<TValue>, TValue, object>(Projection.Property, projections.Cast().To<LambdaExpression>());
 
-        IPropertyGremlinQuery<Property<object>> IEdgeGremlinQueryBase<T1>.Properties(params Expression<Func<T1, Property<object>>>[] projections) => Properties<Property<object>, object, object>(Projection.Property, projections);
+        IPropertyGremlinQuery<Property<object>> IEdgeGremlinQueryBase<T1>.Properties(params Expression<Func<T1, Property<object>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return Properties<Property<object>, object, object>(Projection.Property, projections);
+        }
 
         IPropertyGremlinQuery<Property<object>> IEdgeGremlinQueryBase<T1>.Properties(params ReadOnlySpan<Expression<Func<T1, Property<object>>>> projections) => Properties<Property<object>, object, object>(Projection.Property, projections.Cast().To<LambdaExpression>());
 
@@ -118,21 +153,46 @@ namespace ExRam.Gremlinq.Core
 
         IPropertyGremlinQuery<Property<TValue>> IEdgeGremlinQueryBase.Properties<TValue>() => Properties<Property<TValue>, object, object>(Projection.Property, Array.Empty<string>());
 
-        IInEdgeGremlinQuery<T1, TNewInVertex> IEdgeGremlinQueryBase<T1>.To<TNewInVertex>(StepLabel<TNewInVertex> stepLabel) => To<T1, object, TNewInVertex>(stepLabel);
+        IInEdgeGremlinQuery<T1, TNewInVertex> IEdgeGremlinQueryBase<T1>.To<TNewInVertex>(StepLabel<TNewInVertex> stepLabel)
+        {
+            ArgumentNullException.ThrowIfNull(stepLabel);
 
-        IInEdgeGremlinQuery<T1, TNewInVertex> IEdgeGremlinQueryBase<T1>.To<TNewInVertex>(Func<IVertexGremlinQueryBase, IVertexGremlinQueryBase<TNewInVertex>> toVertexTraversal) => To<object, TNewInVertex>(toVertexTraversal);
+            return To<T1, object, TNewInVertex>(stepLabel);
+        }
 
-        IGremlinQuery<TValue> IEdgeGremlinQueryBase<T1>.Values<TValue>(params Expression<Func<T1, Property<TValue>>>[] projections) => ValuesForProjections<TValue>(projections);
+        IInEdgeGremlinQuery<T1, TNewInVertex> IEdgeGremlinQueryBase<T1>.To<TNewInVertex>(Func<IVertexGremlinQueryBase, IVertexGremlinQueryBase<TNewInVertex>> toVertexTraversal)
+        {
+            ArgumentNullException.ThrowIfNull(toVertexTraversal);
+
+            return To<object, TNewInVertex>(toVertexTraversal);
+        }
+
+        IGremlinQuery<TValue> IEdgeGremlinQueryBase<T1>.Values<TValue>(params Expression<Func<T1, Property<TValue>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TValue>(projections);
+        }
 
         IGremlinQuery<TValue> IEdgeGremlinQueryBase<T1>.Values<TValue>(params ReadOnlySpan<Expression<Func<T1, Property<TValue>>>> projections) => ValuesForProjections<TValue>(projections.Cast().To<LambdaExpression>());
 
-        IGremlinQuery<object> IEdgeGremlinQueryBase<T1>.Values(params Expression<Func<T1, Property<object>>>[] projections) => ValuesForProjections<object>(projections);
+        IGremlinQuery<object> IEdgeGremlinQueryBase<T1>.Values(params Expression<Func<T1, Property<object>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<object>(projections);
+        }
 
         IGremlinQuery<object> IEdgeGremlinQueryBase<T1>.Values(params ReadOnlySpan<Expression<Func<T1, Property<object>>>> projections) => ValuesForProjections<object>(projections.Cast().To<LambdaExpression>());
 
         IEdgeGremlinQuery<T1> IEdgeGremlinQueryBase<T1>.Update(T1 element) => AddOrUpdate(element, false);
 
-        IGremlinQuery<TTarget> IEdgeGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget>>[] projections) => ValuesForProjections<TTarget>(projections);
+        IGremlinQuery<TTarget> IEdgeGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TTarget>(projections);
+        }
 
         IGremlinQuery<TTarget> IEdgeGremlinQueryBase<T1>.Values<TTarget>(params ReadOnlySpan<Expression<Func<T1, TTarget>>> projections) => ValuesForProjections<TTarget>(projections.Cast().To<LambdaExpression>());
 
@@ -154,15 +214,30 @@ namespace ExRam.Gremlinq.Core
 
         IElementGremlinQuery<T1> IElementGremlinQueryBase<T1>.Update(T1 element) => AddOrUpdate(element, false);
 
-        IGremlinQuery<TTarget> IElementGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget>>[] projections) => ValuesForProjections<TTarget>(projections);
+        IGremlinQuery<TTarget> IElementGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TTarget>(projections);
+        }
 
         IGremlinQuery<TTarget> IElementGremlinQueryBase<T1>.Values<TTarget>(params ReadOnlySpan<Expression<Func<T1, TTarget>>> projections) => ValuesForProjections<TTarget>(projections.Cast().To<LambdaExpression>());
 
-        IGremlinQuery<TTarget> IElementGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget[]>>[] projections) => ValuesForProjections<TTarget>(projections);
+        IGremlinQuery<TTarget> IElementGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget[]>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TTarget>(projections);
+        }
 
         IGremlinQuery<TTarget> IElementGremlinQueryBase<T1>.Values<TTarget>(params ReadOnlySpan<Expression<Func<T1, TTarget[]>>> projections) => ValuesForProjections<TTarget>(projections.Cast().To<LambdaExpression>());
 
-        IMapGremlinQuery<IDictionary<string, TTarget>> IElementGremlinQueryBase<T1>.ValueMap<TTarget>(params Expression<Func<T1, TTarget>>[] keys) => ValueMapForExpressions<IDictionary<string, TTarget>>(keys);
+        IMapGremlinQuery<IDictionary<string, TTarget>> IElementGremlinQueryBase<T1>.ValueMap<TTarget>(params Expression<Func<T1, TTarget>>[] keys)
+        {
+            ArgumentNullException.ThrowIfNull(keys);
+
+            return ValueMapForExpressions<IDictionary<string, TTarget>>(keys);
+        }
 
         IMapGremlinQuery<IDictionary<string, TTarget>> IElementGremlinQueryBase<T1>.ValueMap<TTarget>(params ReadOnlySpan<Expression<Func<T1, TTarget>>> keys) => ValueMapForExpressions<IDictionary<string, TTarget>>(keys.Cast().To<LambdaExpression>());
 
@@ -269,15 +344,35 @@ namespace ExRam.Gremlinq.Core
 
         IGremlinQuery<Tree<TRoot>> IGremlinQueryBase.Tree<TRoot>() => Tree<TRoot>();
 
-        IGremlinQuery<TTree> IGremlinQueryBase.Tree<TTree>(Func<ITreeBuilder, ITreeBuilderResult<TTree>> continuation) => Tree(continuation);
+        IGremlinQuery<TTree> IGremlinQueryBase.Tree<TTree>(Func<ITreeBuilder, ITreeBuilderResult<TTree>> continuation)
+        {
+            ArgumentNullException.ThrowIfNull(continuation);
+
+            return Tree(continuation);
+        }
 
         IGremlinQuery<string> IGremlinQueryBase.Profile() => Profile();
 
-        TQuery IGremlinQueryBase.Select<TQuery, TStepElement>(StepLabel<TQuery, TStepElement> label) => Select<TQuery>(label);
+        TQuery IGremlinQueryBase.Select<TQuery, TStepElement>(StepLabel<TQuery, TStepElement> label)
+        {
+            ArgumentNullException.ThrowIfNull(label);
 
-        IArrayGremlinQuery<TNewElement, TNewScalar, TQuery> IGremlinQueryBase.Cap<TNewElement, TNewScalar, TQuery>(StepLabel<IArrayGremlinQuery<TNewElement, TNewScalar, TQuery>, TNewElement> label) => Cap(label);
+            return Select<TQuery>(label);
+        }
 
-        IGremlinQuery<TLabelledElement> IGremlinQueryBase.Select<TLabelledElement>(StepLabel<TLabelledElement> label) => Select(label);
+        IArrayGremlinQuery<TNewElement, TNewScalar, TQuery> IGremlinQueryBase.Cap<TNewElement, TNewScalar, TQuery>(StepLabel<IArrayGremlinQuery<TNewElement, TNewScalar, TQuery>, TNewElement> label)
+        {
+            ArgumentNullException.ThrowIfNull(label);
+
+            return Cap(label);
+        }
+
+        IGremlinQuery<TLabelledElement> IGremlinQueryBase.Select<TLabelledElement>(StepLabel<TLabelledElement> label)
+        {
+            ArgumentNullException.ThrowIfNull(label);
+
+            return Select(label);
+        }
 
         IGremlinQuery<T1> IGremlinQueryBase<T1>.Lower() => this;
 
@@ -287,13 +382,28 @@ namespace ExRam.Gremlinq.Core
 
         IGremlinQuery<object> IGremlinQueryBase.Fail(string? message) => Fail(message);
 
-        TTargetQuery IGremlinQueryAdmin.ConfigureSteps<TTargetQuery>(Func<Traversal, Traversal> transformation, Func<Projection, Projection>? maybeProjectionTransformation) => ConfigureSteps<TTargetQuery>(transformation, maybeProjectionTransformation);
+        TTargetQuery IGremlinQueryAdmin.ConfigureSteps<TTargetQuery>(Func<Traversal, Traversal> transformation, Func<Projection, Projection>? maybeProjectionTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(transformation);
 
-        TTargetQuery IGremlinQueryAdmin.AddStep<TTargetQuery>(Step step, Func<Projection, Projection>? maybeProjectionTransformation) => AddStep<TTargetQuery>(step, maybeProjectionTransformation);
+            return ConfigureSteps<TTargetQuery>(transformation, maybeProjectionTransformation);
+        }
+
+        TTargetQuery IGremlinQueryAdmin.AddStep<TTargetQuery>(Step step, Func<Projection, Projection>? maybeProjectionTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(step);
+
+            return AddStep<TTargetQuery>(step, maybeProjectionTransformation);
+        }
 
         TTargetQuery IGremlinQueryAdmin.ChangeQueryType<TTargetQuery>() => CloneAs<TTargetQuery>();
 
-        TTargetQuery IGremlinQueryAdmin.ConfigureMetadata<TTargetQuery>(Func<IImmutableDictionary<object, object?>, IImmutableDictionary<object, object?>> metadataTransformation) => ConfigureMetadata<TTargetQuery>(metadataTransformation);
+        TTargetQuery IGremlinQueryAdmin.ConfigureMetadata<TTargetQuery>(Func<IImmutableDictionary<object, object?>, IImmutableDictionary<object, object?>> metadataTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(metadataTransformation);
+
+            return ConfigureMetadata<TTargetQuery>(metadataTransformation);
+        }
 
         IGremlinQuerySource IGremlinQueryAdmin.GetSource() => this
             .Continue()
@@ -313,7 +423,12 @@ namespace ExRam.Gremlinq.Core
 
         IVertexGremlinQuery<TVertex> IStartGremlinQuery.AddV<TVertex>(TVertex vertex) => AddV(vertex);
 
-        IGremlinQuery<TNewElement> IStartGremlinQuery.Inject<TNewElement>(params TNewElement[] elements) => Inject(elements);
+        IGremlinQuery<TNewElement> IStartGremlinQuery.Inject<TNewElement>(params TNewElement[] elements)
+        {
+            ArgumentNullException.ThrowIfNull(elements);
+
+            return Inject(elements);
+        }
 
         IGremlinQuery<TNewElement> IStartGremlinQuery.Inject<TNewElement>(params ReadOnlySpan<TNewElement> elements) => Inject(elements);
 
@@ -323,47 +438,122 @@ namespace ExRam.Gremlinq.Core
 
         IVertexGremlinQuery<TVertex> IStartGremlinQuery.AddV<TVertex>() => AddV(new TVertex());
 
-        IVertexGremlinQuery<object> IStartGremlinQuery.V(object id) => V<object>([id]);
+        IVertexGremlinQuery<object> IStartGremlinQuery.V(object id)
+        {
+            ArgumentNullException.ThrowIfNull(id);
 
-        IVertexGremlinQuery<object> IStartGremlinQuery.V(params object[] ids) => V<object>(ids);
+            return V<object>([id]);
+        }
+
+        IVertexGremlinQuery<object> IStartGremlinQuery.V(params object[] ids)
+        {
+            ArgumentNullException.ThrowIfNull(ids);
+
+            return V<object>(ids);
+        }
 
         IVertexGremlinQuery<object> IStartGremlinQuery.V(params ReadOnlySpan<object> ids) => V<object>(ids);
 
-        IVertexGremlinQuery<TVertex> IStartGremlinQuery.V<TVertex>(object id) => V<TVertex>([id]);
+        IVertexGremlinQuery<TVertex> IStartGremlinQuery.V<TVertex>(object id)
+        {
+            ArgumentNullException.ThrowIfNull(id);
 
-        IVertexGremlinQuery<TVertex> IStartGremlinQuery.V<TVertex>(params object[] ids) => V<TVertex>(ids);
+            return V<TVertex>([id]);
+        }
+
+        IVertexGremlinQuery<TVertex> IStartGremlinQuery.V<TVertex>(params object[] ids)
+        {
+            ArgumentNullException.ThrowIfNull(ids);
+
+            return V<TVertex>(ids);
+        }
 
         IVertexGremlinQuery<TVertex> IStartGremlinQuery.V<TVertex>(params ReadOnlySpan<object> ids) => V<TVertex>(ids);
 
-        IEdgeGremlinQuery<object> IStartGremlinQuery.E(object id) => E<object>([id]);
+        IEdgeGremlinQuery<object> IStartGremlinQuery.E(object id)
+        {
+            ArgumentNullException.ThrowIfNull(id);
 
-        IEdgeGremlinQuery<object> IStartGremlinQuery.E(params object[] ids) => E<object>(ids);
+            return E<object>([id]);
+        }
+
+        IEdgeGremlinQuery<object> IStartGremlinQuery.E(params object[] ids)
+        {
+            ArgumentNullException.ThrowIfNull(ids);
+
+            return E<object>(ids);
+        }
 
         IEdgeGremlinQuery<object> IStartGremlinQuery.E(params ReadOnlySpan<object> ids) => E<object>(ids);
 
-        IEdgeGremlinQuery<TEdge> IStartGremlinQuery.E<TEdge>(object id) => E<TEdge>([id]);
+        IEdgeGremlinQuery<TEdge> IStartGremlinQuery.E<TEdge>(object id)
+        {
+            ArgumentNullException.ThrowIfNull(id);
 
-        IEdgeGremlinQuery<TEdge> IStartGremlinQuery.E<TEdge>(params object[] ids) => E<TEdge>(ids);
+            return E<TEdge>([id]);
+        }
+
+        IEdgeGremlinQuery<TEdge> IStartGremlinQuery.E<TEdge>(params object[] ids)
+        {
+            ArgumentNullException.ThrowIfNull(ids);
+
+            return E<TEdge>(ids);
+        }
 
         IEdgeGremlinQuery<TEdge> IStartGremlinQuery.E<TEdge>(params ReadOnlySpan<object> ids) => E<TEdge>(ids);
 
         IEdgeGremlinQuery<TNewEdge> IStartGremlinQuery.ReplaceE<TNewEdge>(TNewEdge edge) => ((IGremlinQuerySource)this).E<TNewEdge>(edge!.GetId(Environment)).Update(edge);
 
-        IGremlinQuerySource IGremlinQuerySource.ConfigureEnvironment(Func<IGremlinQueryEnvironment, IGremlinQueryEnvironment> transformation) => new GremlinQuery<T1, T2, T3, T4>(transformation(Environment), Steps, LabelProjections, Metadata);
+        IGremlinQuerySource IGremlinQuerySource.ConfigureEnvironment(Func<IGremlinQueryEnvironment, IGremlinQueryEnvironment> transformation)
+        {
+            ArgumentNullException.ThrowIfNull(transformation);
 
-        IGremlinQuerySource IGremlinQuerySource.WithSideEffect<TSideEffect>(StepLabel<TSideEffect> label, TSideEffect value) => WithSideEffect(label, value);
+            return new GremlinQuery<T1, T2, T3, T4>(transformation(Environment), Steps, LabelProjections, Metadata);
+        }
 
-        TQuery IGremlinQuerySource.WithSideEffect<TSideEffect, TQuery>(TSideEffect value, Func<IGremlinQuerySource, StepLabel<TSideEffect>, TQuery> continuation) => WithSideEffect(value, continuation);
+        IGremlinQuerySource IGremlinQuerySource.WithSideEffect<TSideEffect>(StepLabel<TSideEffect> label, TSideEffect value)
+        {
+            ArgumentNullException.ThrowIfNull(label);
+
+            return WithSideEffect(label, value);
+        }
+
+        TQuery IGremlinQuerySource.WithSideEffect<TSideEffect, TQuery>(TSideEffect value, Func<IGremlinQuerySource, StepLabel<TSideEffect>, TQuery> continuation)
+        {
+            ArgumentNullException.ThrowIfNull(continuation);
+
+            return WithSideEffect(value, continuation);
+        }
 
         IEdgeGremlinQuery<T1> IInOrOutEdgeGremlinQueryBase<T1, T2>.Lower() => this;
 
-        IEdgeGremlinQuery<T1, TTargetVertex, T2> IInOrOutEdgeGremlinQueryBase<T1, T2>.From<TTargetVertex>(StepLabel<TTargetVertex> stepLabel) => From<T1, TTargetVertex, T2>(stepLabel);
+        IEdgeGremlinQuery<T1, TTargetVertex, T2> IInOrOutEdgeGremlinQueryBase<T1, T2>.From<TTargetVertex>(StepLabel<TTargetVertex> stepLabel)
+        {
+            ArgumentNullException.ThrowIfNull(stepLabel);
 
-        IEdgeGremlinQuery<T1, TNewOutVertex, T2> IInOrOutEdgeGremlinQueryBase<T1, T2>.From<TNewOutVertex>(Func<IVertexGremlinQuery<T2>, IVertexGremlinQueryBase<TNewOutVertex>> fromVertexTraversal) => From(fromVertexTraversal);
+            return From<T1, TTargetVertex, T2>(stepLabel);
+        }
 
-        IEdgeGremlinQuery<T1, T2, TTargetVertex> IInOrOutEdgeGremlinQueryBase<T1, T2>.To<TTargetVertex>(StepLabel<TTargetVertex> stepLabel) => To<T1, T2, TTargetVertex>(stepLabel);
+        IEdgeGremlinQuery<T1, TNewOutVertex, T2> IInOrOutEdgeGremlinQueryBase<T1, T2>.From<TNewOutVertex>(Func<IVertexGremlinQuery<T2>, IVertexGremlinQueryBase<TNewOutVertex>> fromVertexTraversal)
+        {
+            ArgumentNullException.ThrowIfNull(fromVertexTraversal);
 
-        IEdgeGremlinQuery<T1, T2, TTargetVertex> IInOrOutEdgeGremlinQueryBase<T1, T2>.To<TTargetVertex>(Func<IVertexGremlinQuery<T2>, IVertexGremlinQueryBase<TTargetVertex>> toVertexTraversal) => To(toVertexTraversal);
+            return From(fromVertexTraversal);
+        }
+
+        IEdgeGremlinQuery<T1, T2, TTargetVertex> IInOrOutEdgeGremlinQueryBase<T1, T2>.To<TTargetVertex>(StepLabel<TTargetVertex> stepLabel)
+        {
+            ArgumentNullException.ThrowIfNull(stepLabel);
+
+            return To<T1, T2, TTargetVertex>(stepLabel);
+        }
+
+        IEdgeGremlinQuery<T1, T2, TTargetVertex> IInOrOutEdgeGremlinQueryBase<T1, T2>.To<TTargetVertex>(Func<IVertexGremlinQuery<T2>, IVertexGremlinQueryBase<TTargetVertex>> toVertexTraversal)
+        {
+            ArgumentNullException.ThrowIfNull(toVertexTraversal);
+
+            return To(toVertexTraversal);
+        }
 
         IEdgeGremlinQuery<object> IInOrOutEdgeGremlinQueryBase.Lower() => CloneAs<IEdgeGremlinQuery<object>>();
 
@@ -397,7 +587,12 @@ namespace ExRam.Gremlinq.Core
 
         T4 IArrayGremlinQueryBase<T1, T2, T4>.MeanLocal() => MeanLocal<T4>();
 
-        IGremlinQuery<TTargetValue> IMapGremlinQueryBase<T1>.Select<TTargetValue>(Expression<Func<T1, TTargetValue>> projection) => Select<IGremlinQuery<TTargetValue>>(projection);
+        IGremlinQuery<TTargetValue> IMapGremlinQueryBase<T1>.Select<TTargetValue>(Expression<Func<T1, TTargetValue>> projection)
+        {
+            ArgumentNullException.ThrowIfNull(projection);
+
+            return Select<IGremlinQuery<TTargetValue>>(projection);
+        }
 
         IEdgeOrVertexGremlinQuery<T1> IVertexGremlinQueryBase<T1>.Lower() => this;
 
@@ -409,85 +604,180 @@ namespace ExRam.Gremlinq.Core
 
         IVertexPropertyGremlinQuery<VertexProperty<object>, object> IVertexGremlinQueryBase<T1>.Properties() => VertexProperties<object>([]);
 
-        IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, TValue>>[] projections) => VertexProperties<TValue>(projections);
+        IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, TValue>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return VertexProperties<TValue>(projections);
+        }
 
         IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params ReadOnlySpan<Expression<Func<T1, TValue>>> projections) => VertexProperties<TValue>(projections.Cast().To<LambdaExpression>());
 
-        IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, TValue[]>>[] projections) => VertexProperties<TValue>(projections);
+        IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, TValue[]>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return VertexProperties<TValue>(projections);
+        }
 
         IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params ReadOnlySpan<Expression<Func<T1, TValue[]>>> projections) => VertexProperties<TValue>(projections.Cast().To<LambdaExpression>());
 
-        IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, VertexProperty<TValue>>>[] projections) => VertexProperties<TValue>(projections);
+        IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, VertexProperty<TValue>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return VertexProperties<TValue>(projections);
+        }
 
         IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params ReadOnlySpan<Expression<Func<T1, VertexProperty<TValue>>>> projections) => VertexProperties<TValue>(projections.Cast().To<LambdaExpression>());
 
-        IVertexPropertyGremlinQuery<VertexProperty<TValue, TNewMeta>, TValue, TNewMeta> IVertexGremlinQueryBase<T1>.Properties<TValue, TNewMeta>(params Expression<Func<T1, VertexProperty<TValue, TNewMeta>>>[] projections) => VertexProperties<TValue, TNewMeta>(projections);
+        IVertexPropertyGremlinQuery<VertexProperty<TValue, TNewMeta>, TValue, TNewMeta> IVertexGremlinQueryBase<T1>.Properties<TValue, TNewMeta>(params Expression<Func<T1, VertexProperty<TValue, TNewMeta>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return VertexProperties<TValue, TNewMeta>(projections);
+        }
 
         IVertexPropertyGremlinQuery<VertexProperty<TValue, TNewMeta>, TValue, TNewMeta> IVertexGremlinQueryBase<T1>.Properties<TValue, TNewMeta>(params ReadOnlySpan<Expression<Func<T1, VertexProperty<TValue, TNewMeta>>>> projections) => VertexProperties<TValue, TNewMeta>(projections.Cast().To<LambdaExpression>());
 
-        IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, VertexProperty<TValue>[]>>[] projections) => VertexProperties<TValue>(projections);
+        IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params Expression<Func<T1, VertexProperty<TValue>[]>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return VertexProperties<TValue>(projections);
+        }
 
         IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>(params ReadOnlySpan<Expression<Func<T1, VertexProperty<TValue>[]>>> projections) => VertexProperties<TValue>(projections.Cast().To<LambdaExpression>());
 
-        IVertexPropertyGremlinQuery<VertexProperty<TValue, TNewMeta>, TValue, TNewMeta> IVertexGremlinQueryBase<T1>.Properties<TValue, TNewMeta>(params Expression<Func<T1, VertexProperty<TValue, TNewMeta>[]>>[] projections) => VertexProperties<TValue, TNewMeta>(projections);
+        IVertexPropertyGremlinQuery<VertexProperty<TValue, TNewMeta>, TValue, TNewMeta> IVertexGremlinQueryBase<T1>.Properties<TValue, TNewMeta>(params Expression<Func<T1, VertexProperty<TValue, TNewMeta>[]>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return VertexProperties<TValue, TNewMeta>(projections);
+        }
 
         IVertexPropertyGremlinQuery<VertexProperty<TValue, TNewMeta>, TValue, TNewMeta> IVertexGremlinQueryBase<T1>.Properties<TValue, TNewMeta>(params ReadOnlySpan<Expression<Func<T1, VertexProperty<TValue, TNewMeta>[]>>> projections) => VertexProperties<TValue, TNewMeta>(projections.Cast().To<LambdaExpression>());
 
         IVertexPropertyGremlinQuery<VertexProperty<TValue>, TValue> IVertexGremlinQueryBase<T1>.Properties<TValue>() => VertexProperties<TValue>([]);
 
-        IVertexPropertyGremlinQuery<VertexProperty<object>, object> IVertexGremlinQueryBase<T1>.Properties(params Expression<Func<T1, VertexProperty<object>>>[] projections) => VertexProperties<object>(projections);
+        IVertexPropertyGremlinQuery<VertexProperty<object>, object> IVertexGremlinQueryBase<T1>.Properties(params Expression<Func<T1, VertexProperty<object>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return VertexProperties<object>(projections);
+        }
 
         IVertexPropertyGremlinQuery<VertexProperty<object>, object> IVertexGremlinQueryBase<T1>.Properties(params ReadOnlySpan<Expression<Func<T1, VertexProperty<object>>>> projections) => VertexProperties<object>(projections.Cast().To<LambdaExpression>());
 
-        IGremlinQuery<TValue> IVertexGremlinQueryBase<T1>.Values<TValue, TNewMeta>(params Expression<Func<T1, VertexProperty<TValue, TNewMeta>>>[] projections) => ValuesForProjections<TValue>(projections);
+        IGremlinQuery<TValue> IVertexGremlinQueryBase<T1>.Values<TValue, TNewMeta>(params Expression<Func<T1, VertexProperty<TValue, TNewMeta>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TValue>(projections);
+        }
 
         IGremlinQuery<TValue> IVertexGremlinQueryBase<T1>.Values<TValue, TNewMeta>(params ReadOnlySpan<Expression<Func<T1, VertexProperty<TValue, TNewMeta>>>> projections) => ValuesForProjections<TValue>(projections.Cast().To<LambdaExpression>());
 
-        IGremlinQuery<TValue> IVertexGremlinQueryBase<T1>.Values<TValue>(params Expression<Func<T1, VertexProperty<TValue>>>[] projections) => ValuesForProjections<TValue>(projections);
+        IGremlinQuery<TValue> IVertexGremlinQueryBase<T1>.Values<TValue>(params Expression<Func<T1, VertexProperty<TValue>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TValue>(projections);
+        }
 
         IGremlinQuery<TValue> IVertexGremlinQueryBase<T1>.Values<TValue>(params ReadOnlySpan<Expression<Func<T1, VertexProperty<TValue>>>> projections) => ValuesForProjections<TValue>(projections.Cast().To<LambdaExpression>());
 
-        IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, VertexProperty<TTarget>[]>>[] projections) => ValuesForProjections<TTarget>(projections);
+        IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, VertexProperty<TTarget>[]>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TTarget>(projections);
+        }
 
         IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget>(params ReadOnlySpan<Expression<Func<T1, VertexProperty<TTarget>[]>>> projections) => ValuesForProjections<TTarget>(projections.Cast().To<LambdaExpression>());
 
-        IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget, TTargetMeta>(params Expression<Func<T1, VertexProperty<TTarget, TTargetMeta>[]>>[] projections) => ValuesForProjections<TTarget>(projections);
+        IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget, TTargetMeta>(params Expression<Func<T1, VertexProperty<TTarget, TTargetMeta>[]>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TTarget>(projections);
+        }
 
         IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget, TTargetMeta>(params ReadOnlySpan<Expression<Func<T1, VertexProperty<TTarget, TTargetMeta>[]>>> projections) => ValuesForProjections<TTarget>(projections.Cast().To<LambdaExpression>());
 
-        IGremlinQuery<object> IVertexGremlinQueryBase<T1>.Values(params Expression<Func<T1, VertexProperty<object>>>[] projections) => ValuesForProjections<object>(projections);
+        IGremlinQuery<object> IVertexGremlinQueryBase<T1>.Values(params Expression<Func<T1, VertexProperty<object>>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<object>(projections);
+        }
 
         IGremlinQuery<object> IVertexGremlinQueryBase<T1>.Values(params ReadOnlySpan<Expression<Func<T1, VertexProperty<object>>>> projections) => ValuesForProjections<object>(projections.Cast().To<LambdaExpression>());
 
         IVertexGremlinQuery<T1> IVertexGremlinQueryBase<T1>.Update(T1 element) => AddOrUpdate(element, false);
 
-        IVertexGremlinQuery<T1> IVertexGremlinQuery<T1>.Property<TProjectedValue>(Expression<Func<T1, TProjectedValue[]>> projection, TProjectedValue value) => Property(projection, value != null ? new[] { value } : null);
+        IVertexGremlinQuery<T1> IVertexGremlinQuery<T1>.Property<TProjectedValue>(Expression<Func<T1, TProjectedValue[]>> projection, TProjectedValue value)
+        {
+            ArgumentNullException.ThrowIfNull(projection);
 
-        IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget>>[] projections) => ValuesForProjections<TTarget>(projections);
+            return Property(projection, value != null ? new[] { value } : null);
+        }
+
+        IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TTarget>(projections);
+        }
 
         IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget>(params ReadOnlySpan<Expression<Func<T1, TTarget>>> projections) => ValuesForProjections<TTarget>(projections.Cast().To<LambdaExpression>());
 
-        IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget[]>>[] projections) => ValuesForProjections<TTarget>(projections);
+        IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget>(params Expression<Func<T1, TTarget[]>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TTarget>(projections);
+        }
 
         IGremlinQuery<TTarget> IVertexGremlinQueryBase<T1>.Values<TTarget>(params ReadOnlySpan<Expression<Func<T1, TTarget[]>>> projections) => ValuesForProjections<TTarget>(projections.Cast().To<LambdaExpression>());
 
         IElementGremlinQuery<T1> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Lower() => this;
 
-        IPropertyGremlinQuery<Property<TValue>> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Properties<TValue>(params Expression<Func<T3, TValue>>[] projections) => Properties<Property<TValue>, TValue, object>(Projection.Property, projections);
+        IPropertyGremlinQuery<Property<TValue>> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Properties<TValue>(params Expression<Func<T3, TValue>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return Properties<Property<TValue>, TValue, object>(Projection.Property, projections);
+        }
 
         IPropertyGremlinQuery<Property<TValue>> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Properties<TValue>(params ReadOnlySpan<Expression<Func<T3, TValue>>> projections) => Properties<Property<TValue>, TValue, object>(Projection.Property, projections.Cast().To<LambdaExpression>());
 
-        IVertexPropertyGremlinQuery<T1, T2, T3> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Property<TValue>(Expression<Func<T3, TValue>> projection, TValue value) => Property(projection, value);
+        IVertexPropertyGremlinQuery<T1, T2, T3> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Property<TValue>(Expression<Func<T3, TValue>> projection, TValue value)
+        {
+            ArgumentNullException.ThrowIfNull(projection);
+
+            return Property(projection, value);
+        }
 
         IGremlinQuery<T2> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Value() => Value<T2>();
 
         IGremlinQuery<T3> IVertexPropertyGremlinQueryBase<T1, T2, T3>.ValueMap() => ValueMap<T3>([]);
 
-        IGremlinQuery<TTarget> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Values<TTarget>(params Expression<Func<T3, TTarget>>[] projections) => ValuesForProjections<TTarget>(projections);
+        IGremlinQuery<TTarget> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Values<TTarget>(params Expression<Func<T3, TTarget>>[] projections)
+        {
+            ArgumentNullException.ThrowIfNull(projections);
+
+            return ValuesForProjections<TTarget>(projections);
+        }
 
         IGremlinQuery<TTarget> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Values<TTarget>(params ReadOnlySpan<Expression<Func<T3, TTarget>>> projections) => ValuesForProjections<TTarget>(projections.Cast().To<LambdaExpression>());
 
-        IVertexPropertyGremlinQuery<T1, T2, T3> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Where(Expression<Func<VertexProperty<T2, T3>, bool>> predicate) => Where(predicate);
+        IVertexPropertyGremlinQuery<T1, T2, T3> IVertexPropertyGremlinQueryBase<T1, T2, T3>.Where(Expression<Func<VertexProperty<T2, T3>, bool>> predicate)
+        {
+            ArgumentNullException.ThrowIfNull(predicate);
+
+            return Where(predicate);
+        }
 
         IElementGremlinQuery<T1> IVertexPropertyGremlinQueryBase<T1, T2>.Lower() => this;
 
@@ -495,31 +785,61 @@ namespace ExRam.Gremlinq.Core
 
         IMapGremlinQuery<IDictionary<string, TTarget>> IVertexPropertyGremlinQueryBase.ValueMap<TTarget>() => ValueMap<IDictionary<string, TTarget>>([]);
 
-        IMapGremlinQuery<IDictionary<string, TTarget>> IVertexPropertyGremlinQueryBase.ValueMap<TTarget>(params string[] keys) => ValueMap<IDictionary<string, TTarget>>(keys);
+        IMapGremlinQuery<IDictionary<string, TTarget>> IVertexPropertyGremlinQueryBase.ValueMap<TTarget>(params string[] keys)
+        {
+            ArgumentNullException.ThrowIfNull(keys);
+
+            return ValueMap<IDictionary<string, TTarget>>(keys);
+        }
 
         IMapGremlinQuery<IDictionary<string, TTarget>> IVertexPropertyGremlinQueryBase.ValueMap<TTarget>(params ReadOnlySpan<string> keys) => ValueMap<IDictionary<string, TTarget>>(keys);
 
-        IMapGremlinQuery<IDictionary<string, object>> IVertexPropertyGremlinQueryBase.ValueMap(params string[] keys) => ValueMap<IDictionary<string, object>>(keys);
+        IMapGremlinQuery<IDictionary<string, object>> IVertexPropertyGremlinQueryBase.ValueMap(params string[] keys)
+        {
+            ArgumentNullException.ThrowIfNull(keys);
+
+            return ValueMap<IDictionary<string, object>>(keys);
+        }
 
         IMapGremlinQuery<IDictionary<string, object>> IVertexPropertyGremlinQueryBase.ValueMap(params ReadOnlySpan<string> keys) => ValueMap<IDictionary<string, object>>(keys);
 
         IGremlinQuery<TValue> IVertexPropertyGremlinQueryBase.Values<TValue>() => ValuesForStringKeys<TValue>([]);
 
-        IGremlinQuery<TValue> IVertexPropertyGremlinQueryBase.Values<TValue>(params string[] keys) => ValuesForStringKeys<TValue>(keys);
+        IGremlinQuery<TValue> IVertexPropertyGremlinQueryBase.Values<TValue>(params string[] keys)
+        {
+            ArgumentNullException.ThrowIfNull(keys);
+
+            return ValuesForStringKeys<TValue>(keys);
+        }
 
         IGremlinQuery<TValue> IVertexPropertyGremlinQueryBase.Values<TValue>(params ReadOnlySpan<string> keys) => ValuesForStringKeys<TValue>(keys);
 
-        IGremlinQuery<object> IVertexPropertyGremlinQueryBase.Values(params string[] keys) => ValuesForStringKeys<object>(keys);
+        IGremlinQuery<object> IVertexPropertyGremlinQueryBase.Values(params string[] keys)
+        {
+            ArgumentNullException.ThrowIfNull(keys);
+
+            return ValuesForStringKeys<object>(keys);
+        }
 
         IGremlinQuery<object> IVertexPropertyGremlinQueryBase.Values(params ReadOnlySpan<string> keys) => ValuesForStringKeys<object>(keys);
 
-        IPropertyGremlinQuery<Property<object>> IVertexPropertyGremlinQueryBase.Properties(params string[] keys) => Properties<Property<object>, object, object>(Projection.Property, keys);
+        IPropertyGremlinQuery<Property<object>> IVertexPropertyGremlinQueryBase.Properties(params string[] keys)
+        {
+            ArgumentNullException.ThrowIfNull(keys);
+
+            return Properties<Property<object>, object, object>(Projection.Property, keys);
+        }
 
         IPropertyGremlinQuery<Property<object>> IVertexPropertyGremlinQueryBase.Properties(params ReadOnlySpan<string> keys) => Properties<Property<object>, object, object>(Projection.Property, keys);
 
         IVertexPropertyGremlinQuery<VertexProperty<T2, TNewMeta>, T2, TNewMeta> IVertexPropertyGremlinQueryBase<T1, T2>.Meta<TNewMeta>() => CloneAs<IVertexPropertyGremlinQuery<VertexProperty<T2, TNewMeta>, T2, TNewMeta>>();
 
-        IPropertyGremlinQuery<Property<TValue>> IVertexPropertyGremlinQueryBase<T1, T2>.Properties<TValue>(params string[] keys) => Properties<Property<TValue>, object, object>(Projection.Property, keys);
+        IPropertyGremlinQuery<Property<TValue>> IVertexPropertyGremlinQueryBase<T1, T2>.Properties<TValue>(params string[] keys)
+        {
+            ArgumentNullException.ThrowIfNull(keys);
+
+            return Properties<Property<TValue>, object, object>(Projection.Property, keys);
+        }
 
         IPropertyGremlinQuery<Property<TValue>> IVertexPropertyGremlinQueryBase<T1, T2>.Properties<TValue>(params ReadOnlySpan<string> keys) => Properties<Property<TValue>, object, object>(Projection.Property, keys);
 
@@ -553,17 +873,38 @@ namespace ExRam.Gremlinq.Core
 
         IGremlinQuery<long> IDateGremlinQuery<T1>.Diff(DateTimeOffset other) => DateDiff(other);
 
-        IGremlinQuery<long> IDateGremlinQuery<T1>.Diff(Func<IDateGremlinQuery<T1>, IGremlinQueryBase<DateTimeOffset>> other) => DateDiff(other);
+        IGremlinQuery<long> IDateGremlinQuery<T1>.Diff(Func<IDateGremlinQuery<T1>, IGremlinQueryBase<DateTimeOffset>> other)
+        {
+            ArgumentNullException.ThrowIfNull(other);
 
-        IStringGremlinQuery<T1> IStringGremlinQuery<T1>.Concat(params string[] strings) => Concat(strings);
+            return DateDiff(other);
+        }
+
+        IStringGremlinQuery<T1> IStringGremlinQuery<T1>.Concat(params string[] strings)
+        {
+            ArgumentNullException.ThrowIfNull(strings);
+
+            return Concat(strings);
+        }
 
         IStringGremlinQuery<T1> IStringGremlinQuery<T1>.Concat(params ReadOnlySpan<string> strings) => Concat(strings);
 
-        IStringGremlinQuery<T1> IStringGremlinQuery<T1>.Concat(params Func<IStringGremlinQuery<T1>, IGremlinQueryBase<T1>>[] stringTraversals) => Concat(stringTraversals);
+        IStringGremlinQuery<T1> IStringGremlinQuery<T1>.Concat(params Func<IStringGremlinQuery<T1>, IGremlinQueryBase<T1>>[] stringTraversals)
+        {
+            ArgumentNullException.ThrowIfNull(stringTraversals);
+
+            return Concat(stringTraversals);
+        }
 
         IStringGremlinQuery<T1> IStringGremlinQuery<T1>.Concat(params ReadOnlySpan<Func<IStringGremlinQuery<T1>, IGremlinQueryBase<T1>>> stringTraversals) => Concat(stringTraversals.Cast().To<Func<GremlinQuery<T1, T2, T3, T4>, IGremlinQueryBase<T1>>>());
 
-        IStringGremlinQuery<T1> IStringGremlinQuery<T1>.Replace(string oldValue, string newValue) => Replace(oldValue, newValue);
+        IStringGremlinQuery<T1> IStringGremlinQuery<T1>.Replace(string oldValue, string newValue)
+        {
+            ArgumentNullException.ThrowIfNull(oldValue);
+            ArgumentNullException.ThrowIfNull(newValue);
+
+            return Replace(oldValue, newValue);
+        }
 
         IStringGremlinQuery<T1> IStringGremlinQuery<T1>.Reverse() => Reverse();
 
@@ -589,6 +930,11 @@ namespace ExRam.Gremlinq.Core
 
         IStringGremlinQuery<T1> IStringGremlinQuery<T1>.TrimEnd() => TrimEnd();
 
-        IStringGremlinQuery<string> IGremlinQueryBase<T1>.Format(Expression<Func<T1, string>> stringInterpolationExpression) => Format(stringInterpolationExpression);
+        IStringGremlinQuery<string> IGremlinQueryBase<T1>.Format(Expression<Func<T1, string>> stringInterpolationExpression)
+        {
+            ArgumentNullException.ThrowIfNull(stringInterpolationExpression);
+
+            return Format(stringInterpolationExpression);
+        }
     }
 }

--- a/src/Core/Queries/Key.cs
+++ b/src/Core/Queries/Key.cs
@@ -8,11 +8,15 @@ namespace ExRam.Gremlinq.Core
 
         public Key(T t)
         {
+            ArgumentNullException.ThrowIfNull(t);
+
             _key = t;
         }
 
         public Key(string name)
         {
+            ArgumentNullException.ThrowIfNull(name);
+
             _key = name;
         }
 

--- a/src/Core/Queries/Traversal.cs
+++ b/src/Core/Queries/Traversal.cs
@@ -45,10 +45,17 @@ namespace ExRam.Gremlinq.Core
 
         public Traversal Slice(int start, int length) => new (_steps.Slice(start, length), Projection);
 
-        public Traversal WithProjection(Projection projection) => new(_steps, _writeStepsCount, projection);
+        public Traversal WithProjection(Projection projection)
+        {
+            ArgumentNullException.ThrowIfNull(projection);
+
+            return new(_steps, _writeStepsCount, projection);
+        }
 
         public Traversal IncludeProjection(IGremlinQueryEnvironment environment)
         {
+            ArgumentNullException.ThrowIfNull(environment);
+
             if (Projection != Projection.Empty)
             {
                 var projectionTraversal = Projection.ToTraversal(environment);
@@ -81,9 +88,14 @@ namespace ExRam.Gremlinq.Core
 
         public static implicit operator Traversal(Step step) => Create(1, step, static (span, step) => span[0] = step);
 
-        public static Traversal Create<TState>(int length, TState state, SpanAction<Step, TState> action) => new(
-            FastImmutableList<Step>.Create(length, state, action),
-            Projection.Empty);
+        public static Traversal Create<TState>(int length, TState state, SpanAction<Step, TState> action)
+        {
+            ArgumentNullException.ThrowIfNull(action);
+
+            return new(
+                FastImmutableList<Step>.Create(length, state, action),
+                Projection.Empty);
+        }
 
         public int Count => _steps.Count;
 

--- a/src/Core/Serialization/GroovyExpression.cs
+++ b/src/Core/Serialization/GroovyExpression.cs
@@ -20,7 +20,12 @@ namespace ExRam.Gremlinq.Core.Serialization
             _instructions = instructions;
         }
 
-        public static GroovyExpression From(string identifier, ImmutableArray<Instruction> instructions) => new(identifier, instructions);
+        public static GroovyExpression From(string identifier, ImmutableArray<Instruction> instructions)
+        {
+            ArgumentNullException.ThrowIfNull(identifier);
+
+            return new(identifier, instructions);
+        }
 
         public string Identifier => _identifier ?? throw UninitializedStruct();
         public ImmutableArray<Instruction> Instructions => _instructions ?? throw UninitializedStruct();

--- a/src/Core/SerializedQueries/Bindings.cs
+++ b/src/Core/SerializedQueries/Bindings.cs
@@ -24,7 +24,12 @@ namespace ExRam.Gremlinq.Core
 
             bool ICollection<KeyValuePair<object, Label>>.Contains(KeyValuePair<object, Label> item) => false;
 
-            void ICollection<KeyValuePair<object, Label>>.CopyTo(KeyValuePair<object, Label>[] array, int arrayIndex) => throw new NotSupportedException();
+            void ICollection<KeyValuePair<object, Label>>.CopyTo(KeyValuePair<object, Label>[] array, int arrayIndex)
+            {
+                ArgumentNullException.ThrowIfNull(array);
+
+                throw new NotSupportedException();
+            }
 
             IEnumerator<KeyValuePair<object, Label>> IEnumerable<KeyValuePair<object, Label>>.GetEnumerator() => throw new NotSupportedException();
 

--- a/src/Core/SerializedQueries/GroovyGremlinScript.cs
+++ b/src/Core/SerializedQueries/GroovyGremlinScript.cs
@@ -15,7 +15,12 @@ namespace ExRam.Gremlinq.Core.Serialization
             _bindings = bindings ?? ImmutableDictionary<string, object?>.Empty;
         }
 
-        public GroovyGremlinScript Bind(string variable, object? value) => new(Script, Bindings.SetItem(variable, value));
+        public GroovyGremlinScript Bind(string variable, object? value)
+        {
+            ArgumentNullException.ThrowIfNull(variable);
+
+            return new(Script, Bindings.SetItem(variable, value));
+        }
 
         public override string ToString() => Script;
 
@@ -23,6 +28,11 @@ namespace ExRam.Gremlinq.Core.Serialization
 
         public ImmutableDictionary<string, object?> Bindings => _bindings ?? throw UninitializedStruct();
 
-        public static GroovyGremlinScript From(string script, ImmutableDictionary<string, object?>? bindings = null) => new (script, bindings);
+        public static GroovyGremlinScript From(string script, ImmutableDictionary<string, object?>? bindings = null)
+        {
+            ArgumentNullException.ThrowIfNull(script);
+
+            return new (script, bindings);
+        }
     }
 }

--- a/src/Core/Steps/AddEStep.cs
+++ b/src/Core/Steps/AddEStep.cs
@@ -6,6 +6,8 @@
         {
             public FromLabelStep(StepLabel stepLabel)
             {
+                ArgumentNullException.ThrowIfNull(stepLabel);
+
                 StepLabel = stepLabel;
             }
 
@@ -26,6 +28,8 @@
         {
             public ToLabelStep(StepLabel stepLabel)
             {
+                ArgumentNullException.ThrowIfNull(stepLabel);
+
                 StepLabel = stepLabel;
             }
 
@@ -44,6 +48,8 @@
 
         public AddEStep(string label) : base(SideEffectSemanticsChange.Write)
         {
+            ArgumentNullException.ThrowIfNull(label);
+
             Label = label;
         }
 

--- a/src/Core/Steps/AddVStep.cs
+++ b/src/Core/Steps/AddVStep.cs
@@ -4,6 +4,8 @@
     {
         public AddVStep(string label) : base(SideEffectSemanticsChange.Write)
         {
+            ArgumentNullException.ThrowIfNull(label);
+
             Label = label;
         }
 

--- a/src/Core/Steps/AggregateStep.cs
+++ b/src/Core/Steps/AggregateStep.cs
@@ -6,6 +6,9 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public AggregateStep(Scope scope, StepLabel stepLabel) : base(SideEffectSemanticsChange.Write)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+            ArgumentNullException.ThrowIfNull(stepLabel);
+
             Scope = scope;
             StepLabel = stepLabel;
         }

--- a/src/Core/Steps/AsStep.cs
+++ b/src/Core/Steps/AsStep.cs
@@ -4,6 +4,8 @@
     {
         public AsStep(StepLabel stepLabel)
         {
+            ArgumentNullException.ThrowIfNull(stepLabel);
+
             StepLabel = stepLabel;
         }
 

--- a/src/Core/Steps/CapStep.cs
+++ b/src/Core/Steps/CapStep.cs
@@ -4,6 +4,8 @@
     {
         public CapStep(StepLabel stepLabel)
         {
+            ArgumentNullException.ThrowIfNull(stepLabel);
+
             StepLabel = stepLabel;
         }
 

--- a/src/Core/Steps/ChoosePredicateStep.cs
+++ b/src/Core/Steps/ChoosePredicateStep.cs
@@ -7,6 +7,8 @@ namespace ExRam.Gremlinq.Core.Steps
         // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags
         public ChoosePredicateStep(P predicate, Traversal thenTraversal, Traversal? elseTraversal = null) : base(thenTraversal, elseTraversal, thenTraversal.GetSideEffectSemanticsChange() | elseTraversal.GetSideEffectSemanticsChange())
         {
+            ArgumentNullException.ThrowIfNull(predicate);
+
             Predicate = predicate;
         }
 

--- a/src/Core/Steps/CountStep.cs
+++ b/src/Core/Steps/CountStep.cs
@@ -9,6 +9,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public CountStep(Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             Scope = scope;
         }
 

--- a/src/Core/Steps/DateAddStep.cs
+++ b/src/Core/Steps/DateAddStep.cs
@@ -6,6 +6,8 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public DateAddStep(DT dateToken, int value)
         {
+            ArgumentNullException.ThrowIfNull(dateToken);
+
             Value = value;
             DateToken = dateToken;
         }

--- a/src/Core/Steps/DedupStep.cs
+++ b/src/Core/Steps/DedupStep.cs
@@ -9,6 +9,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public DedupStep(Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             Scope = scope;
         }
 

--- a/src/Core/Steps/FormatStep.cs
+++ b/src/Core/Steps/FormatStep.cs
@@ -16,6 +16,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public FormatStep(string format, ImmutableArray<object?> arguments)
         {
+            ArgumentNullException.ThrowIfNull(format);
+
             Format = format;
             Arguments = arguments;
         }

--- a/src/Core/Steps/HasKeyStep.cs
+++ b/src/Core/Steps/HasKeyStep.cs
@@ -4,6 +4,8 @@
     {
         public HasKeyStep(object argument)
         {
+            ArgumentNullException.ThrowIfNull(argument);
+
             Argument = argument;
         }
 

--- a/src/Core/Steps/HasPredicateStep.cs
+++ b/src/Core/Steps/HasPredicateStep.cs
@@ -6,6 +6,8 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public HasPredicateStep(Key key, P predicate)
         {
+            ArgumentNullException.ThrowIfNull(predicate);
+
             Key = key;
             Predicate = predicate;
         }

--- a/src/Core/Steps/HasValueStep.cs
+++ b/src/Core/Steps/HasValueStep.cs
@@ -4,6 +4,8 @@
     {
         public HasValueStep(object argument)
         {
+            ArgumentNullException.ThrowIfNull(argument);
+
             Argument = argument;
         }
 

--- a/src/Core/Steps/IsStep.cs
+++ b/src/Core/Steps/IsStep.cs
@@ -6,6 +6,8 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public IsStep(P predicate)
         {
+            ArgumentNullException.ThrowIfNull(predicate);
+
             Predicate = predicate;
         }
 

--- a/src/Core/Steps/LimitStep.cs
+++ b/src/Core/Steps/LimitStep.cs
@@ -14,6 +14,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public LimitStep(long count, Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 

--- a/src/Core/Steps/MaxStep.cs
+++ b/src/Core/Steps/MaxStep.cs
@@ -9,6 +9,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public MaxStep(Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             Scope = scope;
         }
 

--- a/src/Core/Steps/MeanStep.cs
+++ b/src/Core/Steps/MeanStep.cs
@@ -9,6 +9,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public MeanStep(Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             Scope = scope;
         }
 

--- a/src/Core/Steps/MinStep.cs
+++ b/src/Core/Steps/MinStep.cs
@@ -9,6 +9,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public MinStep(Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             Scope = scope;
         }
 

--- a/src/Core/Steps/OrderStep.cs
+++ b/src/Core/Steps/OrderStep.cs
@@ -15,6 +15,8 @@ namespace ExRam.Gremlinq.Core.Steps
         {
             public ByMemberStep(Key key, Order order)
             {
+                ArgumentNullException.ThrowIfNull(order);
+
                 Order = order;
                 Key = key;
             }
@@ -27,6 +29,8 @@ namespace ExRam.Gremlinq.Core.Steps
         {
             public ByTraversalStep(Traversal traversal, Order order) : base(traversal.GetSideEffectSemanticsChange())
             {
+                ArgumentNullException.ThrowIfNull(order);
+
                 Traversal = traversal;
                 Order = order;
             }
@@ -40,6 +44,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public OrderStep(Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             Scope = scope;
         }
 

--- a/src/Core/Steps/PropertyStep.cs
+++ b/src/Core/Steps/PropertyStep.cs
@@ -9,10 +9,14 @@ namespace ExRam.Gremlinq.Core.Steps
         {
             public ByKeyStep(Key key, object value, Cardinality? cardinality = null) : this(key, value, ImmutableArray<KeyValuePair<string, object>>.Empty, cardinality)
             {
+                ArgumentNullException.ThrowIfNull(value);
+
             }
 
             public ByKeyStep(Key key, object value, ImmutableArray<KeyValuePair<string, object>> metaProperties, Cardinality? cardinality = null) : base(value, metaProperties, cardinality)
             {
+                ArgumentNullException.ThrowIfNull(value);
+
                 Key = key;
             }
 
@@ -23,10 +27,14 @@ namespace ExRam.Gremlinq.Core.Steps
         {
             public ByTraversalStep(Traversal traversal, object value, Cardinality? cardinality = null) : this(traversal, value, ImmutableArray<KeyValuePair<string, object>>.Empty, cardinality)
             {
+                ArgumentNullException.ThrowIfNull(value);
+
             }
 
             public ByTraversalStep(Traversal traversal, object value, ImmutableArray<KeyValuePair<string, object>> metaProperties, Cardinality? cardinality = null) : base(value, metaProperties, cardinality)
             {
+                ArgumentNullException.ThrowIfNull(value);
+
                 Traversal = traversal;
             }
 

--- a/src/Core/Steps/RangeStep.cs
+++ b/src/Core/Steps/RangeStep.cs
@@ -6,6 +6,8 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public RangeStep(long lower, long upper, Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             if (lower < 0)
                 throw new ArgumentOutOfRangeException(nameof(lower));
 

--- a/src/Core/Steps/ReplaceStep.cs
+++ b/src/Core/Steps/ReplaceStep.cs
@@ -4,6 +4,9 @@
     {
         public ReplaceStep(string oldValue, string newValue)
         {
+            ArgumentNullException.ThrowIfNull(oldValue);
+            ArgumentNullException.ThrowIfNull(newValue);
+
             OldValue = oldValue;
             NewValue = newValue;
         }

--- a/src/Core/Steps/SelectColumnStep.cs
+++ b/src/Core/Steps/SelectColumnStep.cs
@@ -6,6 +6,8 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public SelectColumnStep(Column column)
         {
+            ArgumentNullException.ThrowIfNull(column);
+
             Column = column;
         }
 

--- a/src/Core/Steps/SelectStepLabelStep.cs
+++ b/src/Core/Steps/SelectStepLabelStep.cs
@@ -6,6 +6,8 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public SelectStepLabelStep(StepLabel stepLabel) : this(ImmutableArray.Create(stepLabel))
         {
+            ArgumentNullException.ThrowIfNull(stepLabel);
+
         }
 
         public SelectStepLabelStep(ImmutableArray<StepLabel> stepLabels)

--- a/src/Core/Steps/SkipStep.cs
+++ b/src/Core/Steps/SkipStep.cs
@@ -6,6 +6,8 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public SkipStep(long count, Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 

--- a/src/Core/Steps/SubstringStep.cs
+++ b/src/Core/Steps/SubstringStep.cs
@@ -6,6 +6,8 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public SubstringStep(Range range, Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             Range = range;
             Scope = scope;
         }

--- a/src/Core/Steps/SumStep.cs
+++ b/src/Core/Steps/SumStep.cs
@@ -9,6 +9,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public SumStep(Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             Scope = scope;
         }
 

--- a/src/Core/Steps/TailStep.cs
+++ b/src/Core/Steps/TailStep.cs
@@ -14,6 +14,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public TailStep(long count, Scope scope)
         {
+            ArgumentNullException.ThrowIfNull(scope);
+
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 

--- a/src/Core/Steps/WherePredicateStep.cs
+++ b/src/Core/Steps/WherePredicateStep.cs
@@ -16,6 +16,8 @@ namespace ExRam.Gremlinq.Core.Steps
 
         public WherePredicateStep(P predicate)
         {
+            ArgumentNullException.ThrowIfNull(predicate);
+
             Predicate = predicate;
         }
 

--- a/src/Core/Steps/WhereStepLabelAndPredicateStep.cs
+++ b/src/Core/Steps/WhereStepLabelAndPredicateStep.cs
@@ -6,6 +6,9 @@ namespace ExRam.Gremlinq.Core.Steps
     {
         public WhereStepLabelAndPredicateStep(StepLabel stepLabel, P predicate)
         {
+            ArgumentNullException.ThrowIfNull(stepLabel);
+            ArgumentNullException.ThrowIfNull(predicate);
+
             StepLabel = stepLabel;
             Predicate = predicate;
         }

--- a/src/Core/Steps/WithSideEffectStep.cs
+++ b/src/Core/Steps/WithSideEffectStep.cs
@@ -4,6 +4,9 @@
     {
         public WithSideEffectStep(StepLabel label, object value)
         {
+            ArgumentNullException.ThrowIfNull(label);
+            ArgumentNullException.ThrowIfNull(value);
+
             Label = label;
             Value = value;
         }

--- a/src/Core/Transformation/Converters/ConverterFactory.cs
+++ b/src/Core/Transformation/Converters/ConverterFactory.cs
@@ -158,10 +158,20 @@ namespace ExRam.Gremlinq.Core.Transformation
         }
 
         public static IConverterFactory Create<TStaticSource, TStaticTarget>(Func<TStaticSource, IGremlinQueryEnvironment, ITransformer, ITransformer, TStaticTarget?> func)
-            where TStaticTarget : struct => new StructFuncConverterFactory<TStaticSource, TStaticTarget>(func);
+            where TStaticTarget : struct
+        {
+            ArgumentNullException.ThrowIfNull(func);
+
+            return new StructFuncConverterFactory<TStaticSource, TStaticTarget>(func);
+        }
 
         public static IConverterFactory Create<TStaticSource, TStaticTarget>(Func<TStaticSource, IGremlinQueryEnvironment, ITransformer, ITransformer, TStaticTarget?> func)
-            where TStaticTarget : class => new ClassFuncConverterFactory<TStaticSource, TStaticTarget>(func);
+            where TStaticTarget : class
+        {
+            ArgumentNullException.ThrowIfNull(func);
+
+            return new ClassFuncConverterFactory<TStaticSource, TStaticTarget>(func);
+        }
 
         internal static IConverterFactory Chain<TStaticSource, TIntermediateSource, TStaticTarget>() => new ChainConverterFactory<TStaticSource, TIntermediateSource, TStaticTarget>();
     }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,11 +8,6 @@
     <Product>ExRam.Gremlinq</Product>
     <Deterministic>true</Deterministic>
     <NoWarn>IDE0303;IDE0301$(NoWarn)</NoWarn>
-    <WeaverConfiguration>
-      <Weavers>
-        <RuntimeNullables CheckNonPublic="false" CheckOutputs="false" />
-      </Weavers>
-    </WeaverConfiguration>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   
@@ -41,8 +36,4 @@
    <PackageReference Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'" Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Fody" PrivateAssets="All" />
-    <PackageReference Include="RuntimeNullables.Fody" PrivateAssets="All" />
-  </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,8 +32,11 @@
   <ItemGroup Condition="'$(Configuration)' == 'Release'" >
     <None Include="$(PackageLicenseDirectory)$(PackageLicenseFile)" Pack="true" PackagePath="/" />
     <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath="/" />
-   
    <PackageReference Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'" Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsRoslynComponent)' != 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Analyzers\ExRam.Gremlinq.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Providers.Core/BinaryMessages/GraphSon2BinaryMessage.cs
+++ b/src/Providers.Core/BinaryMessages/GraphSon2BinaryMessage.cs
@@ -10,6 +10,8 @@ namespace ExRam.Gremlinq.Providers.Core
 
         public GraphSon2BinaryMessage(IMemoryOwner<byte> owner)
         {
+            ArgumentNullException.ThrowIfNull(owner);
+
             _owner = owner;
         }
 

--- a/src/Providers.Core/BinaryMessages/GraphSon3BinaryMessage.cs
+++ b/src/Providers.Core/BinaryMessages/GraphSon3BinaryMessage.cs
@@ -10,6 +10,8 @@ namespace ExRam.Gremlinq.Providers.Core
 
         public GraphSon3BinaryMessage(IMemoryOwner<byte> owner)
         {
+            ArgumentNullException.ThrowIfNull(owner);
+
             _owner = owner;
         }
 

--- a/src/Providers.Core/Extensions/GremlinQueryEnvironmentExtensions.cs
+++ b/src/Providers.Core/Extensions/GremlinQueryEnvironmentExtensions.cs
@@ -25,9 +25,14 @@ namespace ExRam.Gremlinq.Providers.Core
             MaxDepth = 128
         };
 
-        public static IGremlinQueryEnvironment AddGraphSonBinarySupport(this IGremlinQueryEnvironment environment) => environment
-            .AddGraphSonBinarySupport(new GraphSON2Writer(), GraphSon2Header, owner => new GraphSon2BinaryMessage(owner))
-            .AddGraphSonBinarySupport(new GraphSON3Writer(), GraphSon3Header, owner => new GraphSon3BinaryMessage(owner));
+        public static IGremlinQueryEnvironment AddGraphSonBinarySupport(this IGremlinQueryEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+
+            return environment
+                .AddGraphSonBinarySupport(new GraphSON2Writer(), GraphSon2Header, owner => new GraphSon2BinaryMessage(owner))
+                .AddGraphSonBinarySupport(new GraphSON3Writer(), GraphSon3Header, owner => new GraphSon3BinaryMessage(owner));
+        }
 
         private static byte[] GetHeader(string mimeType) => mimeType.Length <= 255
             ? Encoding.UTF8.GetBytes($"{(char)mimeType.Length}{mimeType}")

--- a/src/Providers.Core/Extensions/GremlinqClientExtensions.cs
+++ b/src/Providers.Core/Extensions/GremlinqClientExtensions.cs
@@ -231,11 +231,28 @@ namespace ExRam.Gremlinq.Providers.Core
             public void Dispose() => _innerClient.Dispose();
         }
 
-        public static IGremlinqClient TransformRequest(this IGremlinqClient client, Func<RequestMessage, CancellationToken, Task<RequestMessage>> transformation) => new RequestInterceptingGremlinqClient(client, transformation);
+        public static IGremlinqClient TransformRequest(this IGremlinqClient client, Func<RequestMessage, CancellationToken, Task<RequestMessage>> transformation)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+            ArgumentNullException.ThrowIfNull(transformation);
 
-        public static IGremlinqClient ObserveResultStatusAttributes(this IGremlinqClient client, Action<RequestMessage, IReadOnlyDictionary<string, object>> observer) => new ObserveResultStatusAttributesGremlinqClient(client, observer);
+            return new RequestInterceptingGremlinqClient(client, transformation);
+        }
 
-        public static IGremlinqClient Throttle(this IGremlinqClient client, int maxConcurrency) => new ThrottledGremlinqClient(client, maxConcurrency);
+        public static IGremlinqClient ObserveResultStatusAttributes(this IGremlinqClient client, Action<RequestMessage, IReadOnlyDictionary<string, object>> observer)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+            ArgumentNullException.ThrowIfNull(observer);
+
+            return new ObserveResultStatusAttributesGremlinqClient(client, observer);
+        }
+
+        public static IGremlinqClient Throttle(this IGremlinqClient client, int maxConcurrency)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+
+            return new ThrottledGremlinqClient(client, maxConcurrency);
+        }
 
         internal static IGremlinqClient Log(this IGremlinqClient client, IGremlinQueryEnvironment environment) => new LoggingGremlinqClient(client, environment);
 

--- a/src/Providers.Core/Extensions/ProviderConfiguratorExtensions.cs
+++ b/src/Providers.Core/Extensions/ProviderConfiguratorExtensions.cs
@@ -3,21 +3,45 @@
     public static class ProviderConfiguratorExtensions
     {
         public static TConfigurator At<TConfigurator>(this IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> builder, string uri)
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => builder.At(new Uri(uri));
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(uri);
+
+            return builder.At(new Uri(uri));
+        }
 
         public static TConfigurator AtLocalhost<TConfigurator>(this IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> builder)
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => builder.At(new Uri("ws://localhost:8182"));
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            return builder.At(new Uri("ws://localhost:8182"));
+        }
 
         public static TConfigurator At<TConfigurator>(this IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> configurator, Uri uri)
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => configurator
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(uri);
+
+            return configurator
                 .ConfigureClientFactory(factory => factory
                     .ConfigureBaseFactory(factory => factory
                         .ConfigureUri(_ => uri)));
+        }
 
         public static TConfigurator AuthenticateBy<TConfigurator>(this IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> configurator, string username, string password)
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => configurator
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(username);
+            ArgumentNullException.ThrowIfNull(password);
+
+            return configurator
                 .ConfigureClientFactory(factory => factory
                     .ConfigureBaseFactory(factory => factory
                         .WithPlainCredentials(username, password)));
+        }
     }
 }

--- a/src/Providers.Core/Factory/GremlinqClientFactory.cs
+++ b/src/Providers.Core/Factory/GremlinqClientFactory.cs
@@ -280,7 +280,12 @@ namespace ExRam.Gremlinq.Providers.Core
         }
 
         public static TClientFactory ConfigureClient<TClientFactory>(this TClientFactory clientFactory, Func<IGremlinqClient, IGremlinqClient> clientTransformation)
-            where TClientFactory : IGremlinqClientFactory<TClientFactory> => clientFactory.ConfigureClient((client, _) => clientTransformation(client));
+            where TClientFactory : IGremlinqClientFactory<TClientFactory>
+        {
+            ArgumentNullException.ThrowIfNull(clientTransformation);
+
+            return clientFactory.ConfigureClient((client, _) => clientTransformation(client));
+        }
 
         public static IPoolGremlinqClientFactory<TBaseFactory> Pool<TBaseFactory>(this TBaseFactory baseFactory)
             where TBaseFactory : IGremlinqClientFactory => new PoolGremlinqClientFactory<TBaseFactory>(baseFactory, 8, 16, static (client, _) => client);
@@ -288,6 +293,11 @@ namespace ExRam.Gremlinq.Providers.Core
         public static TClientFactory Log<TClientFactory>(this TClientFactory clientFactory)
             where TClientFactory : IGremlinqClientFactory<TClientFactory> => clientFactory.ConfigureClient((client, environment) => client.Log(environment));
 
-        public static IGremlinQueryExecutor ToExecutor(this IGremlinqClientFactory clientFactory) => new GremlinQueryExecutorImpl(clientFactory);
+        public static IGremlinQueryExecutor ToExecutor(this IGremlinqClientFactory clientFactory)
+        {
+            ArgumentNullException.ThrowIfNull(clientFactory);
+
+            return new GremlinQueryExecutorImpl(clientFactory);
+        }
     }
 }

--- a/src/Providers.Core/Factory/WebSocketGremlinqClientFactory.cs
+++ b/src/Providers.Core/Factory/WebSocketGremlinqClientFactory.cs
@@ -225,7 +225,12 @@ namespace ExRam.Gremlinq.Providers.Core
 
                     ValueTaskSourceStatus IValueTaskSource<SingleOrQueue<T>>.GetStatus(short token) => _valueTaskSource.GetStatus(token);
 
-                    void IValueTaskSource<SingleOrQueue<T>>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) => _valueTaskSource.OnCompleted(continuation, state, token, flags);
+                    void IValueTaskSource<SingleOrQueue<T>>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+                    {
+                        ArgumentNullException.ThrowIfNull(continuation);
+
+                        _valueTaskSource.OnCompleted(continuation, state, token, flags);
+                    }
                 }
 
                 private record struct ResponseMessagePayload<T>(ResponseResult<T>? Result);
@@ -480,12 +485,19 @@ namespace ExRam.Gremlinq.Providers.Core
 
         public static readonly IWebSocketGremlinqClientFactory LocalHost = WebSocketGremlinqClientFactoryImpl<GraphSon3BinaryMessage>.LocalHost;
 
-        public static IWebSocketGremlinqClientFactory WithPlainCredentials(this IWebSocketGremlinqClientFactory factory, string username, string password) => factory
-            .ConfigureAuthentication(_ => _ => RequestMessage
-                .Build(Tokens.OpsAuthentication)
-                .Processor(Tokens.ProcessorTraversal)
-                .AddArgument(Tokens.ArgsSasl, Convert.ToBase64String(Encoding.UTF8.GetBytes($"\0{username}\0{password}")))
-                .Create());
+        public static IWebSocketGremlinqClientFactory WithPlainCredentials(this IWebSocketGremlinqClientFactory factory, string username, string password)
+        {
+            ArgumentNullException.ThrowIfNull(factory);
+            ArgumentNullException.ThrowIfNull(username);
+            ArgumentNullException.ThrowIfNull(password);
+
+            return factory
+                .ConfigureAuthentication(_ => _ => RequestMessage
+                    .Build(Tokens.OpsAuthentication)
+                    .Processor(Tokens.ProcessorTraversal)
+                    .AddArgument(Tokens.ArgsSasl, Convert.ToBase64String(Encoding.UTF8.GetBytes($"\0{username}\0{password}")))
+                    .Create());
+        }
 
         private static readonly string UserAgent = $"{typeof(IGremlinQueryBase).Assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product}/{typeof(WebSocketGremlinqClientFactory).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion} {Environment.OSVersion.VersionString};";
     }

--- a/src/Providers.CosmosDb.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
+++ b/src/Providers.CosmosDb.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
@@ -7,12 +7,16 @@ namespace ExRam.Gremlinq.Providers.CosmosDb.AspNet
 {
     public static class GremlinqServicesBuilderExtensions
     {
-        public static IGremlinqServicesBuilder<ICosmosDbConfigurator<TVertexBase>> UseCosmosDb<TVertexBase, TEdgeBase>(this IGremlinqServicesBuilder setup) => setup
-            .ConfigureBase()
-            .UseProvider<ICosmosDbConfigurator<TVertexBase>>(source => source
-                .UseCosmosDb<TVertexBase, TEdgeBase>)
-            .Configure((configurator, gremlinqSection) =>
-            {
+        public static IGremlinqServicesBuilder<ICosmosDbConfigurator<TVertexBase>> UseCosmosDb<TVertexBase, TEdgeBase>(this IGremlinqServicesBuilder setup)
+        {
+            ArgumentNullException.ThrowIfNull(setup);
+
+            return setup
+                .ConfigureBase()
+                .UseProvider<ICosmosDbConfigurator<TVertexBase>>(source => source
+                    .UseCosmosDb<TVertexBase, TEdgeBase>)
+                .Configure((configurator, gremlinqSection) =>
+                {
                 var providerSection = gremlinqSection
                     .GetSection("CosmosDb");
 
@@ -58,6 +62,7 @@ namespace ExRam.Gremlinq.Providers.CosmosDb.AspNet
                 }
 
                 return configurator;
-            });
+                });
+        }
     }
 }

--- a/src/Providers.CosmosDb/CosmosDbKey.cs
+++ b/src/Providers.CosmosDb/CosmosDbKey.cs
@@ -6,10 +6,15 @@
 
         public CosmosDbKey(string id) : this(null, id, false)
         {
+            ArgumentNullException.ThrowIfNull(id);
+
         }
 
         public CosmosDbKey(string partitionKey, string id) : this(partitionKey, id, false)
         {
+            ArgumentNullException.ThrowIfNull(partitionKey);
+            ArgumentNullException.ThrowIfNull(id);
+
         }
 
         private CosmosDbKey(string? partitionKey, string id, bool _)

--- a/src/Providers.CosmosDb/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/Providers.CosmosDb/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -150,9 +150,14 @@ namespace ExRam.Gremlinq.Providers.CosmosDb
 
         private static readonly NotStep NoneWorkaround = new(IdentityStep.Instance);
 
-        public static IGremlinQuerySource UseCosmosDb<TVertexBase, TEdgeBase>(this IGremlinQuerySource source, Func<ICosmosDbConfigurator<TVertexBase>, IGremlinQuerySourceTransformation> configuratorTransformation) => configuratorTransformation
-            .Invoke(CosmosDbConfigurator<TVertexBase>.Default)
-            .Transform(source
+        public static IGremlinQuerySource UseCosmosDb<TVertexBase, TEdgeBase>(this IGremlinQuerySource source, Func<ICosmosDbConfigurator<TVertexBase>, IGremlinQuerySourceTransformation> configuratorTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(configuratorTransformation);
+
+            return configuratorTransformation
+                .Invoke(CosmosDbConfigurator<TVertexBase>.Default)
+                .Transform(source
                 .ConfigureEnvironment(environment => environment
                     .UseModel(GraphModel
                         .FromBaseTypes<TVertexBase, TEdgeBase>())
@@ -221,6 +226,7 @@ namespace ExRam.Gremlinq.Providers.CosmosDb
                                     ? WorkaroundOrder.Decr
                                     : null)))
                     .ConfigureDeserializer(deserializer => deserializer
-                        .AsIncomplete())));
+                        .AsIncomplete())));    
+        }
     }
 }

--- a/src/Providers.CosmosDb/Extensions/CosmosDbConfiguratorExtensions.cs
+++ b/src/Providers.CosmosDb/Extensions/CosmosDbConfiguratorExtensions.cs
@@ -4,14 +4,37 @@ namespace ExRam.Gremlinq.Providers.CosmosDb
 {
     public static class CosmosDbConfiguratorExtensions
     {
-        public static ICosmosDbConfigurator<TVertexBase> At<TVertexBase>(this ICosmosDbConfigurator<TVertexBase> configurator, string uri, string databaseName, string graphName) => configurator
-            .At(new Uri(uri), databaseName, graphName);
+        public static ICosmosDbConfigurator<TVertexBase> At<TVertexBase>(this ICosmosDbConfigurator<TVertexBase> configurator, string uri, string databaseName, string graphName)
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(uri);
+            ArgumentNullException.ThrowIfNull(databaseName);
+            ArgumentNullException.ThrowIfNull(graphName);
 
-        public static ICosmosDbConfigurator<TVertexBase> At<TVertexBase>(this ICosmosDbConfigurator<TVertexBase> configurator, Uri uri, string databaseName, string graphName) => configurator
-            .At(uri)
-            .OnDatabase(databaseName)
-            .OnGraph(graphName);
+            return configurator
+                .At(new Uri(uri), databaseName, graphName);
+        }
 
-        public static ICosmosDbConfigurator<TVertexBase> AtLocalhost<TVertexBase>(this ICosmosDbConfigurator<TVertexBase> configurator, string databaseName, string graphName) => configurator.At("ws://localhost:8182", databaseName, graphName);
+        public static ICosmosDbConfigurator<TVertexBase> At<TVertexBase>(this ICosmosDbConfigurator<TVertexBase> configurator, Uri uri, string databaseName, string graphName)
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(uri);
+            ArgumentNullException.ThrowIfNull(databaseName);
+            ArgumentNullException.ThrowIfNull(graphName);
+
+            return configurator
+                .At(uri)
+                .OnDatabase(databaseName)
+                .OnGraph(graphName);
+        }
+
+        public static ICosmosDbConfigurator<TVertexBase> AtLocalhost<TVertexBase>(this ICosmosDbConfigurator<TVertexBase> configurator, string databaseName, string graphName)
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(databaseName);
+            ArgumentNullException.ThrowIfNull(graphName);
+
+            return configurator.At("ws://localhost:8182", databaseName, graphName);
+        }
     }
 }

--- a/src/Providers.GremlinServer.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
+++ b/src/Providers.GremlinServer.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
@@ -4,18 +4,23 @@ namespace ExRam.Gremlinq.Providers.GremlinServer.AspNet
 {
     public static class GremlinqServicesBuilderExtensions
     {
-        public static IGremlinqServicesBuilder<IGremlinServerConfigurator> UseGremlinServer<TVertex, TEdge>(this IGremlinqServicesBuilder setup) => setup
-            .ConfigureBase()
-            .UseProvider<IGremlinServerConfigurator>(source => source
-                .UseGremlinServer<TVertex, TEdge>)
-            .Configure((configurator, section) =>
-            {
-                var providerSection = section
-                    .GetSection("GremlinServer");
+        public static IGremlinqServicesBuilder<IGremlinServerConfigurator> UseGremlinServer<TVertex, TEdge>(this IGremlinqServicesBuilder setup)
+        {
+            ArgumentNullException.ThrowIfNull(setup);
 
-                return configurator
-                    .ConfigureWebSocket(providerSection)
-                    .ConfigureBasicAuthentication(providerSection);
-            });
+            return setup
+                .ConfigureBase()
+                .UseProvider<IGremlinServerConfigurator>(source => source
+                    .UseGremlinServer<TVertex, TEdge>)
+                .Configure((configurator, section) =>
+                {
+                    var providerSection = section
+                        .GetSection("GremlinServer");
+
+                    return configurator
+                        .ConfigureWebSocket(providerSection)
+                        .ConfigureBasicAuthentication(providerSection);
+                });
+        }
     }
 }

--- a/src/Providers.GremlinServer/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/Providers.GremlinServer/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -35,9 +35,14 @@ namespace ExRam.Gremlinq.Providers.GremlinServer
                             .ToExecutor())));
         }
 
-        public static IGremlinQuerySource UseGremlinServer<TVertexBase, TEdgeBase>(this IGremlinQuerySource source, Func<IGremlinServerConfigurator, IGremlinQuerySourceTransformation> configuratorTransformation) => configuratorTransformation
-            .Invoke(GremlinServerConfigurator.Default)
-            .Transform(source
+        public static IGremlinQuerySource UseGremlinServer<TVertexBase, TEdgeBase>(this IGremlinQuerySource source, Func<IGremlinServerConfigurator, IGremlinQuerySourceTransformation> configuratorTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(configuratorTransformation);
+
+            return configuratorTransformation
+                .Invoke(GremlinServerConfigurator.Default)
+                .Transform(source
                 .ConfigureEnvironment(environment => environment
                     .UseModel(GraphModel
                         .FromBaseTypes<TVertexBase, TEdgeBase>())
@@ -50,6 +55,7 @@ namespace ExRam.Gremlinq.Providers.GremlinServer
                         .ConfigureEdgeFeatures(edgeProperties => edgeProperties & ~(EdgeFeatures.Upsert | EdgeFeatures.CustomIds)))
                     .AddGraphSonBinarySupport()
                     .ConfigureDeserializer(deserializer => deserializer
-                        .AsIncomplete())));
+                        .AsIncomplete())));    
+        }
     }
 }

--- a/src/Providers.JanusGraph.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
+++ b/src/Providers.JanusGraph.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
@@ -4,18 +4,23 @@ namespace ExRam.Gremlinq.Providers.JanusGraph.AspNet
 {
     public static class GremlinqServicesBuilderExtensions
     {
-        public static IGremlinqServicesBuilder<IJanusGraphConfigurator> UseJanusGraph<TVertexBase, TEdgeBase>(this IGremlinqServicesBuilder setup) => setup
-            .ConfigureBase()
-            .UseProvider<IJanusGraphConfigurator>(source => source
-                .UseJanusGraph<TVertexBase, TEdgeBase>)
-            .Configure((configurator, section) =>
-            {
-                var providerSection = section
-                    .GetSection("JanusGraph");
+        public static IGremlinqServicesBuilder<IJanusGraphConfigurator> UseJanusGraph<TVertexBase, TEdgeBase>(this IGremlinqServicesBuilder setup)
+        {
+            ArgumentNullException.ThrowIfNull(setup);
 
-                return configurator
-                    .ConfigureWebSocket(providerSection)
-                    .ConfigureBasicAuthentication(providerSection);
-            });
+            return setup
+                .ConfigureBase()
+                .UseProvider<IJanusGraphConfigurator>(source => source
+                    .UseJanusGraph<TVertexBase, TEdgeBase>)
+                .Configure((configurator, section) =>
+                {
+                    var providerSection = section
+                        .GetSection("JanusGraph");
+
+                    return configurator
+                        .ConfigureWebSocket(providerSection)
+                        .ConfigureBasicAuthentication(providerSection);
+                });
+        }
     }
 }

--- a/src/Providers.JanusGraph/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/Providers.JanusGraph/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -35,9 +35,14 @@ namespace ExRam.Gremlinq.Providers.JanusGraph
                             .ToExecutor())));
         }
 
-        public static IGremlinQuerySource UseJanusGraph<TVertexBase, TEdgeBase>(this IGremlinQuerySource source, Func<IJanusGraphConfigurator, IGremlinQuerySourceTransformation> configuratorTransformation) => configuratorTransformation
-            .Invoke(JanusGraphConfigurator.Default)
-            .Transform(source
+        public static IGremlinQuerySource UseJanusGraph<TVertexBase, TEdgeBase>(this IGremlinQuerySource source, Func<IJanusGraphConfigurator, IGremlinQuerySourceTransformation> configuratorTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(configuratorTransformation);
+
+            return configuratorTransformation
+                .Invoke(JanusGraphConfigurator.Default)
+                .Transform(source
                 .ConfigureEnvironment(environment => environment
                     .UseModel(GraphModel
                         .FromBaseTypes<TVertexBase, TEdgeBase>())
@@ -53,5 +58,6 @@ namespace ExRam.Gremlinq.Providers.JanusGraph
                     .AddGraphSonBinarySupport()
                     .ConfigureDeserializer(deserializer => deserializer
                         .AsIncomplete())));
+        }
     }
 }

--- a/src/Providers.Neptune.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
+++ b/src/Providers.Neptune.AspNet/Extensions/GremlinqServicesBuilderExtensions.cs
@@ -23,12 +23,16 @@ namespace ExRam.Gremlinq.Providers.Neptune.AspNet
                 : configurator.UseIAMAuthentication(_signer);
         }
 
-        public static IGremlinqServicesBuilder<INeptuneConfigurator> UseNeptune<TVertexBase, TEdgeBase>(this IGremlinqServicesBuilder setup) => setup
-            .ConfigureBase()
-            .UseProvider<INeptuneConfigurator>(source => source
-                .UseNeptune<TVertexBase, TEdgeBase>)
-            .Configure((configurator, gremlinqSection) =>
-            {
+        public static IGremlinqServicesBuilder<INeptuneConfigurator> UseNeptune<TVertexBase, TEdgeBase>(this IGremlinqServicesBuilder setup)
+        {
+            ArgumentNullException.ThrowIfNull(setup);
+
+            return setup
+                .ConfigureBase()
+                .UseProvider<INeptuneConfigurator>(source => source
+                    .UseNeptune<TVertexBase, TEdgeBase>)
+                .Configure((configurator, gremlinqSection) =>
+                {
                 var providerSection = gremlinqSection
                     .GetSection("Neptune");
 
@@ -59,11 +63,14 @@ namespace ExRam.Gremlinq.Providers.Neptune.AspNet
                 }
 
                 return configurator;
-            });
+                });
+        }
 
         public static IGremlinqServicesBuilder<TConfigurator> UseIAMAuthentication<TConfigurator>(this IGremlinqServicesBuilder<TConfigurator> builder)
             where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
         {
+            ArgumentNullException.ThrowIfNull(builder);
+
             builder.Services
                 .AddSingleton<IAWSSigner>(ctx =>
                 {

--- a/src/Providers.Neptune/AWSSigner/AWSSigner.cs
+++ b/src/Providers.Neptune/AWSSigner/AWSSigner.cs
@@ -46,7 +46,12 @@ namespace ExRam.Gremlinq.Providers.Neptune
 
                 int IReadOnlyCollection<KeyValuePair<string, string>>.Count => 4;
 
-                bool IReadOnlyDictionary<string, string>.ContainsKey(string key) => ((IReadOnlyDictionary<string, string>)this).TryGetValue(key, out _);
+                bool IReadOnlyDictionary<string, string>.ContainsKey(string key)
+                {
+                    ArgumentNullException.ThrowIfNull(key);
+
+                    return ((IReadOnlyDictionary<string, string>)this).TryGetValue(key, out _);
+                }
 
                 IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator() => ((IEnumerable<KeyValuePair<string, string>>)_kvps).GetEnumerator();
 
@@ -54,6 +59,8 @@ namespace ExRam.Gremlinq.Providers.Neptune
 
                 bool IReadOnlyDictionary<string, string>.TryGetValue(string key, out string value)
                 {
+                    ArgumentNullException.ThrowIfNull(key);
+
                     for (var i = 0; i < _kvps.Length; i++)
                     {
                         if (_kvps[i].Key == key)
@@ -253,6 +260,9 @@ namespace ExRam.Gremlinq.Providers.Neptune
 
         public static HttpRequestMessage Sign(this IAWSSigner signer, HttpRequestMessage request, DateTimeOffset? time = null)
         {
+            ArgumentNullException.ThrowIfNull(signer);
+            ArgumentNullException.ThrowIfNull(request);
+
             if (request.Method != HttpMethod.Get)
                 throw new NotSupportedException($"The {request.Method}-method is not supported.");
 
@@ -263,17 +273,37 @@ namespace ExRam.Gremlinq.Providers.Neptune
             return request;
         }
 
-        public static ISigV4AWSSigner WithUri(this ISigV4AWSSigner signer, Uri uri) => signer
-            .ConfigureUri(_ => uri);
+        public static ISigV4AWSSigner WithUri(this ISigV4AWSSigner signer, Uri uri)
+        {
+            ArgumentNullException.ThrowIfNull(signer);
+            ArgumentNullException.ThrowIfNull(uri);
 
-        public static ISigV4AWSSigner WithRegion(this ISigV4AWSSigner signer, string region) => signer
-            .ConfigureRegion(_ => region);
+            return signer
+                .ConfigureUri(_ => uri);
+        }
 
-        public static ISigV4AWSSigner WithCacheTime(this ISigV4AWSSigner signer, TimeSpan cacheTime) => signer
-            .ConfigureCacheTime(_ => cacheTime);
+        public static ISigV4AWSSigner WithRegion(this ISigV4AWSSigner signer, string region)
+        {
+            ArgumentNullException.ThrowIfNull(signer);
+            ArgumentNullException.ThrowIfNull(region);
+
+            return signer
+                .ConfigureRegion(_ => region);
+        }
+
+        public static ISigV4AWSSigner WithCacheTime(this ISigV4AWSSigner signer, TimeSpan cacheTime)
+        {
+            ArgumentNullException.ThrowIfNull(signer);
+
+            return signer
+                .ConfigureCacheTime(_ => cacheTime);
+        }
 
         public static HttpHeaders Sign(this IAWSSigner signer, HttpHeaders headers, DateTimeOffset? time = null)
         {
+            ArgumentNullException.ThrowIfNull(signer);
+            ArgumentNullException.ThrowIfNull(headers);
+
             foreach (var kvp in signer.GetIAMHeaders(time))
             {
                 headers.TryAddWithoutValidation(kvp.Key, kvp.Value);

--- a/src/Providers.Neptune/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
+++ b/src/Providers.Neptune/Extensions/ConfigurableGremlinQuerySourceExtensions.cs
@@ -39,9 +39,14 @@ namespace ExRam.Gremlinq.Providers.Neptune
                             .ToExecutor())));
         }
 
-        public static IGremlinQuerySource UseNeptune<TVertexBase, TEdgeBase>(this IGremlinQuerySource source, Func<INeptuneConfigurator, IGremlinQuerySourceTransformation> configuratorTransformation) => configuratorTransformation
-            .Invoke(NeptuneConfigurator.Default)
-            .Transform(source
+        public static IGremlinQuerySource UseNeptune<TVertexBase, TEdgeBase>(this IGremlinQuerySource source, Func<INeptuneConfigurator, IGremlinQuerySourceTransformation> configuratorTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(configuratorTransformation);
+
+            return configuratorTransformation
+                .Invoke(NeptuneConfigurator.Default)
+                .Transform(source
                 .ConfigureEnvironment(environment => environment
                     .UseModel(GraphModel
                         .FromBaseTypes<TVertexBase, TEdgeBase>())
@@ -68,5 +73,6 @@ namespace ExRam.Gremlinq.Providers.Neptune
             .ConfigureEnvironment(environment => environment
                 .ConfigureExecutor(executor => executor
                     .TransformExecutionException(ex => ex.TryGetNeptuneGremlinQueryExecutionException() ?? ex)));
+        }
     }
 }

--- a/src/Providers.Neptune/Extensions/GremlinQuerySourceExtensions.cs
+++ b/src/Providers.Neptune/Extensions/GremlinQuerySourceExtensions.cs
@@ -6,7 +6,12 @@ namespace ExRam.Gremlinq.Providers.Neptune
     {
         private static readonly StepLabel<bool> UseDFEStepLabel = "Neptune#useDFE";
 
-        public static IGremlinQuerySource UseDFE(this IGremlinQuerySource source, bool enabled = true) => source
-            .WithSideEffect(UseDFEStepLabel, enabled);
+        public static IGremlinQuerySource UseDFE(this IGremlinQuerySource source, bool enabled = true)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return source
+                .WithSideEffect(UseDFEStepLabel, enabled);
+        }
     }
 }

--- a/src/Providers.Neptune/Extensions/NeptuneConfiguratorExtensions.cs
+++ b/src/Providers.Neptune/Extensions/NeptuneConfiguratorExtensions.cs
@@ -100,11 +100,20 @@ namespace ExRam.Gremlinq.Providers.Neptune
         }
 
         public static TConfigurator UseIAMAuthentication<TConfigurator>(this TConfigurator configurator, Func<IDisabledAWSSigner, IAWSSigner> builderTransformation)
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => configurator
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(builderTransformation);
+
+            return configurator
                 .UseIAMAuthentication(builderTransformation(AWSSigner.Disabled));
+        }
 
         public static TConfigurator UseIAMAuthentication<TConfigurator>(this TConfigurator configurator, IAWSSigner signer)
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => configurator
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(signer);
+
+            return configurator
                 .ConfigureClientFactory(factory => factory
                     .ConfigureBaseFactory(factory => factory
                         .ConfigureClientWebSocketFactory(factory => () =>
@@ -118,10 +127,17 @@ namespace ExRam.Gremlinq.Providers.Neptune
 
                             return client;
                         })));
+        }
 
-        public static INeptuneConfigurator UseElasticSearch(this INeptuneConfigurator configurator, Uri elasticSearchEndPoint, NeptuneElasticSearchIndexConfiguration indexConfiguration = NeptuneElasticSearchIndexConfiguration.Standard) => new ElasticSearchAwareNeptuneConfigurator(
-            configurator,
-            elasticSearchEndPoint,
-            indexConfiguration);
+        public static INeptuneConfigurator UseElasticSearch(this INeptuneConfigurator configurator, Uri elasticSearchEndPoint, NeptuneElasticSearchIndexConfiguration indexConfiguration = NeptuneElasticSearchIndexConfiguration.Standard)
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(elasticSearchEndPoint);
+
+            return new ElasticSearchAwareNeptuneConfigurator(
+                configurator,
+                elasticSearchEndPoint,
+                indexConfiguration);
+        }
     }
 }

--- a/src/Providers.Neptune/NeptuneErrorCode.cs
+++ b/src/Providers.Neptune/NeptuneErrorCode.cs
@@ -36,7 +36,12 @@ namespace ExRam.Gremlinq.Providers.Neptune
             _code = code;
         }
 
-        public static NeptuneErrorCode From(string code) => new (code);
+        public static NeptuneErrorCode From(string code)
+        {
+            ArgumentNullException.ThrowIfNull(code);
+
+            return new (code);
+        }
 
         public override bool Equals(object? obj) => obj is NeptuneErrorCode code && Equals(code);
 

--- a/src/Providers.Neptune/NeptuneGremlinQueryExecutionException.cs
+++ b/src/Providers.Neptune/NeptuneGremlinQueryExecutionException.cs
@@ -6,11 +6,16 @@ namespace ExRam.Gremlinq.Providers.Neptune
     {
         public NeptuneGremlinQueryExecutionException(NeptuneErrorCode code, GremlinQueryExecutionContext executionContext, string message, Exception innerException) : base(executionContext, message, innerException)
         {
+            ArgumentNullException.ThrowIfNull(message);
+            ArgumentNullException.ThrowIfNull(innerException);
+
             Code = code;
         }
 
         public NeptuneGremlinQueryExecutionException(NeptuneErrorCode code, GremlinQueryExecutionContext executionContext, Exception innerException) : base(executionContext, innerException)
         {
+            ArgumentNullException.ThrowIfNull(innerException);
+
             Code = code;
         }
 

--- a/src/Support.NewtonsoftJson.AspNet/GremlinqServicesBuilderExtensions.cs
+++ b/src/Support.NewtonsoftJson.AspNet/GremlinqServicesBuilderExtensions.cs
@@ -4,9 +4,14 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson.AspNet
 {
     public static class GremlinqServicesBuilderExtensions
     {
-        public static IGremlinqServicesBuilder UseNewtonsoftJson(this IGremlinqServicesBuilder builder) => builder
-            .ConfigureQuerySource((source, _) => source
-                .ConfigureEnvironment(env => env
-                    .UseNewtonsoftJson()));
+        public static IGremlinqServicesBuilder UseNewtonsoftJson(this IGremlinqServicesBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            return builder
+                .ConfigureQuerySource((source, _) => source
+                    .ConfigureEnvironment(env => env
+                        .UseNewtonsoftJson()));
+        }
     }
 }

--- a/src/Support.NewtonsoftJson/Converters/DynamicObjectConverterFactory.cs
+++ b/src/Support.NewtonsoftJson/Converters/DynamicObjectConverterFactory.cs
@@ -48,21 +48,51 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
 
                 object? IDictionary<string, object?>.this[string key] { get => _dictionary[key]; set => _dictionary[key] = value; }
 
-                bool IReadOnlyDictionary<string, object?>.ContainsKey(string key) => _dictionary.ContainsKey(key);
+                bool IReadOnlyDictionary<string, object?>.ContainsKey(string key)
+                {
+                    ArgumentNullException.ThrowIfNull(key);
+
+                    return _dictionary.ContainsKey(key);
+                }
 
                 IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => _dictionary.GetEnumerator();
 
-                bool IReadOnlyDictionary<string, object?>.TryGetValue(string key, out object? value) => _dictionary.TryGetValue(key, out value);
+                bool IReadOnlyDictionary<string, object?>.TryGetValue(string key, out object? value)
+                {
+                    ArgumentNullException.ThrowIfNull(key);
+
+                    return _dictionary.TryGetValue(key, out value);
+                }
 
                 IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_dictionary).GetEnumerator();
 
-                void IDictionary<string, object?>.Add(string key, object? value) => _dictionary.Add(key, value);
+                void IDictionary<string, object?>.Add(string key, object? value)
+                {
+                    ArgumentNullException.ThrowIfNull(key);
 
-                bool IDictionary<string, object?>.ContainsKey(string key) => _dictionary.ContainsKey(key);
+                    _dictionary.Add(key, value);
+                }
 
-                bool IDictionary<string, object?>.Remove(string key) => _dictionary.Remove(key);
+                bool IDictionary<string, object?>.ContainsKey(string key)
+                {
+                    ArgumentNullException.ThrowIfNull(key);
 
-                bool IDictionary<string, object?>.TryGetValue(string key, out object? value) => _dictionary.TryGetValue(key, out value);
+                    return _dictionary.ContainsKey(key);
+                }
+
+                bool IDictionary<string, object?>.Remove(string key)
+                {
+                    ArgumentNullException.ThrowIfNull(key);
+
+                    return _dictionary.Remove(key);
+                }
+
+                bool IDictionary<string, object?>.TryGetValue(string key, out object? value)
+                {
+                    ArgumentNullException.ThrowIfNull(key);
+
+                    return _dictionary.TryGetValue(key, out value);
+                }
 
                 void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item) => _dictionary.Add(item);
 
@@ -70,7 +100,12 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
 
                 bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item) => _dictionary.Contains(item);
 
-                void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex) => _dictionary.CopyTo(array, arrayIndex);
+                void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex)
+                {
+                    ArgumentNullException.ThrowIfNull(array);
+
+                    _dictionary.CopyTo(array, arrayIndex);
+                }
 
                 bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => _dictionary.Remove(item);
             }

--- a/src/Support.NewtonsoftJson/Extensions/GremlinQueryEnvironmentExtensions.cs
+++ b/src/Support.NewtonsoftJson/Extensions/GremlinQueryEnvironmentExtensions.cs
@@ -85,7 +85,11 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
                 : null;
         }
 
-        public static IGremlinQueryEnvironment UseNewtonsoftJson(this IGremlinQueryEnvironment environment) => environment
+        public static IGremlinQueryEnvironment UseNewtonsoftJson(this IGremlinQueryEnvironment environment)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+
+            return environment
             .ConfigureDeserializer(deserializer => deserializer
                 .Add(new DeferToNewtonsoftConverterFactory())
                 .Add(new NewtonsoftJsonSerializerConverterFactory())
@@ -112,13 +116,21 @@ namespace ExRam.Gremlinq.Support.NewtonsoftJson
                 .Add(new TimeSpanConverterFactory())
                 .Add(new DateTimeOffsetConverterFactory())
                 .Add(new DateTimeConverterFactory()));
+        }
 
-        public static IGremlinQueryEnvironment RegisterNativeType<TNative, TSerialized>(this IGremlinQueryEnvironment environment, Func<TNative, IGremlinQueryEnvironment, ITransformer, ITransformer, TSerialized> serializer, Func<JValue, IGremlinQueryEnvironment, ITransformer, ITransformer, TNative> deserializer) => environment
-            .ConfigureNativeTypes(_ => _
-                .Add(typeof(TNative)))
-            .ConfigureSerializer(_ => _
-                .Add(new NativeTypeSerializerConverterFactory<TNative, TSerialized>(serializer)))
-            .ConfigureDeserializer(_ => _
-                .Add(new NativeTypeDeserializerConverterFactory<TNative>(deserializer)));
+        public static IGremlinQueryEnvironment RegisterNativeType<TNative, TSerialized>(this IGremlinQueryEnvironment environment, Func<TNative, IGremlinQueryEnvironment, ITransformer, ITransformer, TSerialized> serializer, Func<JValue, IGremlinQueryEnvironment, ITransformer, ITransformer, TNative> deserializer)
+        {
+            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(serializer);
+            ArgumentNullException.ThrowIfNull(deserializer);
+
+            return environment
+                .ConfigureNativeTypes(_ => _
+                    .Add(typeof(TNative)))
+                .ConfigureSerializer(_ => _
+                    .Add(new NativeTypeSerializerConverterFactory<TNative, TSerialized>(serializer)))
+                .ConfigureDeserializer(_ => _
+                    .Add(new NativeTypeDeserializerConverterFactory<TNative>(deserializer)));
+        }
     }
 }

--- a/src/Support.TestContainers/ProviderConfiguratorExtensions.cs
+++ b/src/Support.TestContainers/ProviderConfiguratorExtensions.cs
@@ -7,12 +7,24 @@ namespace ExRam.Gremlinq.Support.TestContainers
     public static class ProviderConfiguratorExtensions
     {
         public static TConfigurator UseTestContainers<TConfigurator>(this IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> configurator, Func<TestContainersConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> continuation)
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => configurator
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(continuation);
+
+            return configurator
                 .ConfigureClientFactory(factory => continuation(new TestContainersConfigurator(factory)));
+        }
 
         public static TConfigurator UseGremlinServerContainer<TConfigurator>(this IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> configurator, string tag = "latest")
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => configurator
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(tag);
+
+            return configurator
                 .UseTestContainersWithDefaultSetup("tinkerpop/gremlin-server", tag);
+        }
 
         /// <summary>
         ///  Runs a container from the 'ghcr.io/gremlinq/gremlin-server-mod' image upon GremlinClient creation.
@@ -23,12 +35,24 @@ namespace ExRam.Gremlinq.Support.TestContainers
         /// <param name="tag"></param>
         /// <returns></returns>
         public static TConfigurator UseGremlinServerModContainer<TConfigurator>(this IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> configurator, string tag = "3")
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => configurator
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(tag);
+
+            return configurator
                 .UseTestContainersWithDefaultSetup("ghcr.io/gremlinq/gremlin-server-mod", tag);
+        }
 
         public static TConfigurator UseJanusGraphContainer<TConfigurator>(this IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> configurator, string tag = "latest")
-            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => configurator
+            where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>>
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+            ArgumentNullException.ThrowIfNull(tag);
+
+            return configurator
                 .UseTestContainersWithDefaultSetup("janusgraph/janusgraph", tag);
+        }
 
         private static TConfigurator UseTestContainersWithDefaultSetup<TConfigurator>(this IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> configurator, string image, string tag)
             where TConfigurator : IProviderConfigurator<TConfigurator, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> => configurator

--- a/src/Support.TestContainers/TestContainersConfigurator.cs
+++ b/src/Support.TestContainers/TestContainersConfigurator.cs
@@ -13,8 +13,13 @@ namespace ExRam.Gremlinq.Support.TestContainers
             _clientFactory = clientFactory;
         }
 
-        public TestContainersWithContainerConfigurator ConfigureContainer(Func<ContainerBuilder, ContainerBuilder> containerBuilderTransformation) => _clientFactory is { } clientFactory
-            ? new TestContainersWithContainerConfigurator(clientFactory, containerBuilderTransformation)
-            : throw new InvalidOperationException();
+        public TestContainersWithContainerConfigurator ConfigureContainer(Func<ContainerBuilder, ContainerBuilder> containerBuilderTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(containerBuilderTransformation);
+
+            return _clientFactory is { } clientFactory
+                ? new TestContainersWithContainerConfigurator(clientFactory, containerBuilderTransformation)
+                : throw new InvalidOperationException();
+        }
     }
 }

--- a/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
+++ b/src/Support.TestContainers/TestContainersWithContainerConfigurator.cs
@@ -144,8 +144,13 @@ namespace ExRam.Gremlinq.Support.TestContainers
             _containerBuilderTransformation = containerBuilderTransformation;
         }
 
-        public IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory> ConfigureClientFactory(Func<IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>, IContainer, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> factoryTransformation) => _clientFactory is { } clientFactory && _containerBuilderTransformation is { } containerBuilderTransformation
-            ? new ContainerGremlinqClientFactory(clientFactory, containerBuilderTransformation, factoryTransformation)
-            : throw new InvalidOperationException();
+        public IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory> ConfigureClientFactory(Func<IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>, IContainer, IPoolGremlinqClientFactory<IWebSocketGremlinqClientFactory>> factoryTransformation)
+        {
+            ArgumentNullException.ThrowIfNull(factoryTransformation);
+
+            return _clientFactory is { } clientFactory && _containerBuilderTransformation is { } containerBuilderTransformation
+                ? new ContainerGremlinqClientFactory(clientFactory, containerBuilderTransformation, factoryTransformation)
+                : throw new InvalidOperationException();
+        }
     }
 }

--- a/src/Testing.AirRoutes.Generator/AirRoutesGenerator.cs
+++ b/src/Testing.AirRoutes.Generator/AirRoutesGenerator.cs
@@ -39,6 +39,8 @@ namespace ExRam.Gremlinq.Testing.AirRoutes.Generator
                                     /// </summary>
                                     public static async Task RemoveAirRoutes(this IGremlinQuerySource source, CancellationToken ct = default)
                                     {
+                                        ArgumentNullException.ThrowIfNull(source);
+
                                         await source
                                             .ConfigureEnvironment(env => env
                                                 .UseModel(GraphModel.FromBaseTypes<Airport, Route>()))
@@ -132,6 +134,9 @@ namespace ExRam.Gremlinq.Testing.AirRoutes.Generator
                                 .WriteLine($"public static async Task {methodName}(this IGremlinQuerySource source, CancellationToken ct = default)")
                                 .Block(writer =>
                                 {
+                                    writer = writer
+                                        .WriteLine("ArgumentNullException.ThrowIfNull(source);");
+
                                     if (graphml.Graph?.Node is { } nodes && graphml.Graph?.Edge is { } edges)
                                     {
                                         writer = writer

--- a/test/Core.Tests/GraphModelTest.cs
+++ b/test/Core.Tests/GraphModelTest.cs
@@ -1,11 +1,20 @@
 ﻿using ExRam.Gremlinq.Core.Models;
 using ExRam.Gremlinq.Tests.Entities;
 using FluentAssertions;
+using static ExRam.Gremlinq.Core.GremlinQuerySource;
 
 namespace ExRam.Gremlinq.Core.Tests
 {
     public class GraphModelTest
     {
+        [Fact]
+        public void ConfigureEnvironment_may_not_be_passed_null() => g
+            .Invoking(_ => _
+                .ConfigureEnvironment(null!))
+            .Should()
+            .ThrowExactly<ArgumentNullException>()
+            .WithMessage("Value cannot be null. (Parameter 'transformation')");
+
         [Fact]
         public void MemberMetadata_name_cannot_be_null()
         {

--- a/test/Core.Tests/GraphModelTest.cs
+++ b/test/Core.Tests/GraphModelTest.cs
@@ -1,20 +1,11 @@
 ﻿using ExRam.Gremlinq.Core.Models;
 using ExRam.Gremlinq.Tests.Entities;
 using FluentAssertions;
-using static ExRam.Gremlinq.Core.GremlinQuerySource;
 
 namespace ExRam.Gremlinq.Core.Tests
 {
     public class GraphModelTest
     {
-        [Fact]
-        public void Fody_works() => g
-            .Invoking(_ => _
-                .ConfigureEnvironment(null!))
-            .Should()
-            .ThrowExactly<ArgumentNullException>()
-            .WithMessage("Value cannot be null. (Parameter 'transformation')");
-
         [Fact]
         public void MemberMetadata_name_cannot_be_null()
         {


### PR DESCRIPTION
Fix all warnings the analyzer produces.