### PR TITLE
Improve solution-wide code coverage

### DIFF
--- a/test/Core.AspNet.Tests/GremlinqConfigurationSectionTests.cs
+++ b/test/Core.AspNet.Tests/GremlinqConfigurationSectionTests.cs
@@ -1,3 +1,5 @@
+using FluentAssertions;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -34,5 +36,69 @@ namespace ExRam.Gremlinq.Core.AspNet.Tests
         public Task General_config() => Verify((
             _section["Gremlinq_key_1"],
             _section["Gremlinq_key_2"]));
+
+        [Fact]
+        public void GetChildren_returns_children()
+        {
+            _section.GetChildren()
+                .Should()
+                .NotBeNull();
+        }
+
+        [Fact]
+        public void GetReloadToken_returns_token()
+        {
+            _section.GetReloadToken()
+                .Should()
+                .NotBeNull();
+        }
+
+        [Fact]
+        public void Indexer_set()
+        {
+            _section["Gremlinq_key_1"] = "updated";
+
+            _section["Gremlinq_key_1"].Should().Be("updated");
+        }
+
+        [Fact]
+        public void Value_set()
+        {
+            _section.Value = "some_value";
+
+            _section.Value.Should().Be("some_value");
+        }
+
+        [Fact]
+        public void Key_returns_key()
+        {
+            _section.Key.Should().Be("Gremlinq");
+        }
+
+        [Fact]
+        public void Path_returns_path()
+        {
+            _section.Path.Should().Be("Gremlinq");
+        }
+
+        [Fact]
+        public void GetSection_returns_section()
+        {
+            _section.GetSection("Gremlinq_key_1")
+                .Should()
+                .NotBeNull();
+
+            _section.GetSection("Gremlinq_key_1").Value
+                .Should()
+                .Be("value1");
+        }
+
+        [Fact]
+        public void GetSection_null_throws()
+        {
+            FluentActions.Invoking(() => _section.GetSection(null!))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
     }
 }

--- a/test/Core.AspNet.Tests/GremlinqServicesBuilderTests.cs
+++ b/test/Core.AspNet.Tests/GremlinqServicesBuilderTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExRam.Gremlinq.Core.AspNet.Tests
+{
+    public class GremlinqServicesBuilderTests
+    {
+        [Fact]
+        public void ConfigureQuerySource_with_section()
+        {
+            var source = new ServiceCollection()
+                .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        { "Gremlinq:Alias", "g" }
+                    })
+                    .Build())
+                .AddGremlinq(builder => builder
+                    .ConfigureQuerySource((source, section) => source))
+                .BuildServiceProvider()
+                .GetRequiredService<IGremlinQuerySource>();
+
+            source.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void FromBaseSection()
+        {
+            var section = new ServiceCollection()
+                .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        { "MyApp:Gremlinq:key1", "value1" }
+                    })
+                    .Build())
+                .AddGremlinq(builder => builder
+                    .FromBaseSection("MyApp"))
+                .BuildServiceProvider()
+                .GetRequiredService<IGremlinqConfigurationSection>();
+
+            section["key1"].Should().Be("value1");
+        }
+
+        [Fact]
+        public void FromBaseSection_overrides_default()
+        {
+            var section = new ServiceCollection()
+                .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        { "Gremlinq:defaultKey", "defaultValue" },
+                        { "CustomSection:Gremlinq:customKey", "customValue" }
+                    })
+                    .Build())
+                .AddGremlinq(builder => builder
+                    .FromBaseSection("CustomSection"))
+                .BuildServiceProvider()
+                .GetRequiredService<IGremlinqConfigurationSection>();
+
+            section["customKey"].Should().Be("customValue");
+            section["defaultKey"].Should().BeNull();
+        }
+
+        [Fact]
+        public void ConfigureQuerySource_generic()
+        {
+            var source = new ServiceCollection()
+                .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>())
+                    .Build())
+                .AddGremlinq(builder => builder
+                    .ConfigureQuerySource<NoOpTransformation>())
+                .BuildServiceProvider()
+                .GetRequiredService<IGremlinQuerySource>();
+
+            source.Should().NotBeNull();
+        }
+
+        private class NoOpTransformation : IGremlinQuerySourceTransformation
+        {
+            public IGremlinQuerySource Transform(IGremlinQuerySource source) => source;
+        }
+    }
+}

--- a/test/Core.Tests/Elements/ElementTests.cs
+++ b/test/Core.Tests/Elements/ElementTests.cs
@@ -1,0 +1,243 @@
+using ExRam.Gremlinq.Core.GraphElements;
+
+using FluentAssertions;
+
+namespace ExRam.Gremlinq.Core.Tests
+{
+    public class PropertyTests
+    {
+        [Fact]
+        public void Constructor_sets_value()
+        {
+            var prop = new Property<string>("hello");
+
+            prop.Value.Should().Be("hello");
+        }
+
+        [Fact]
+        public void Constructor_null_value_throws()
+        {
+            FluentActions.Invoking(() => new Property<string>(null!))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Value_setter_null_throws()
+        {
+            var prop = new Property<string>("hello");
+
+            prop.Invoking(p => p.Value = null!)
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Value_setter_updates_value()
+        {
+            var prop = new Property<string>("hello");
+
+            prop.Value = "world";
+
+            prop.Value.Should().Be("world");
+        }
+
+        [Fact]
+        public void ToString_format()
+        {
+            var prop = new Property<int>(42);
+
+            prop.ToString().Should().Contain("42");
+            prop.ToString().Should().StartWith("p[");
+        }
+
+        [Fact]
+        public void Implicit_conversion_from_value()
+        {
+            Property<string> prop = "test";
+
+            prop.Value.Should().Be("test");
+        }
+
+        [Fact]
+        public void Implicit_conversion_from_array_throws()
+        {
+            FluentActions.Invoking(() =>
+            {
+                Property<string> _ = new[] { "a", "b" };
+            })
+            .Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void Implicit_conversion_from_property_array_throws()
+        {
+            FluentActions.Invoking(() =>
+            {
+                Property<string> _ = new Property<string>[] { new("a"), new("b") };
+            })
+            .Should().Throw<NotSupportedException>();
+        }
+    }
+
+    public class VertexPropertyTests
+    {
+        [Fact]
+        public void Constructor_sets_value()
+        {
+            var vp = new VertexProperty<string>("hello");
+
+            vp.Value.Should().Be("hello");
+        }
+
+        [Fact]
+        public void Constructor_initializes_dictionary()
+        {
+            var vp = new VertexProperty<string>("hello");
+
+            vp.Properties.Should().NotBeNull();
+            vp.Properties.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ToString_format()
+        {
+            var vp = new VertexProperty<int>(42);
+
+            vp.ToString().Should().Contain("42");
+            vp.ToString().Should().StartWith("vp[");
+        }
+
+        [Fact]
+        public void Implicit_conversion_from_value()
+        {
+            VertexProperty<string> vp = "test";
+
+            vp.Value.Should().Be("test");
+        }
+
+        [Fact]
+        public void Implicit_conversion_from_array_throws()
+        {
+            FluentActions.Invoking(() =>
+            {
+                VertexProperty<string> _ = new[] { "a", "b" };
+            })
+            .Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void Implicit_conversion_from_vp_array_throws()
+        {
+            FluentActions.Invoking(() =>
+            {
+                VertexProperty<string> _ = new VertexProperty<string>[] { new("a") };
+            })
+            .Should().Throw<NotSupportedException>();
+        }
+    }
+
+    public class VertexPropertyWithMetaTests
+    {
+        private sealed class Meta
+        {
+            public string? Description { get; set; }
+        }
+
+        [Fact]
+        public void Constructor_sets_value()
+        {
+            var vp = new VertexProperty<string, Meta>("hello");
+
+            vp.Value.Should().Be("hello");
+        }
+
+        [Fact]
+        public void ToString_format()
+        {
+            var vp = new VertexProperty<int, Meta>(42);
+
+            vp.ToString().Should().Contain("42");
+            vp.ToString().Should().StartWith("vp[");
+        }
+
+        [Fact]
+        public void Implicit_conversion_from_value()
+        {
+            VertexProperty<string, Meta> vp = "test";
+
+            vp.Value.Should().Be("test");
+        }
+
+        [Fact]
+        public void Implicit_conversion_from_array_throws()
+        {
+            FluentActions.Invoking(() =>
+            {
+                VertexProperty<string, Meta> _ = new[] { "a", "b" };
+            })
+            .Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void Implicit_conversion_from_vp_array_throws()
+        {
+            FluentActions.Invoking(() =>
+            {
+                VertexProperty<string, Meta> _ = new VertexProperty<string, Meta>[] { new("a") };
+            })
+            .Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void Properties_can_be_set()
+        {
+            var vp = new VertexProperty<string, Meta>("hello");
+            var meta = new Meta { Description = "desc" };
+
+            vp.Properties = meta;
+
+            vp.Properties.Should().BeSameAs(meta);
+        }
+    }
+
+    public class PathTests
+    {
+        [Fact]
+        public void Default_Labels_is_empty()
+        {
+            var path = new GraphElements.Path();
+
+            path.Labels.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Default_Objects_is_empty()
+        {
+            var path = new GraphElements.Path();
+
+            path.Objects.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Labels_can_be_set()
+        {
+            var path = new GraphElements.Path
+            {
+                Labels = [["a", "b"], ["c"]]
+            };
+
+            path.Labels.Should().HaveCount(2);
+            path.Labels[0].Should().ContainInOrder("a", "b");
+        }
+
+        [Fact]
+        public void Objects_can_be_set()
+        {
+            var path = new GraphElements.Path
+            {
+                Objects = [1, "two", 3.0]
+            };
+
+            path.Objects.Should().HaveCount(3);
+        }
+    }
+}

--- a/test/Core.Tests/ExpressionParsing/ExpressionNotSupportedExceptionTests.cs
+++ b/test/Core.Tests/ExpressionParsing/ExpressionNotSupportedExceptionTests.cs
@@ -1,0 +1,117 @@
+using System.Linq.Expressions;
+
+using FluentAssertions;
+
+namespace ExRam.Gremlinq.Core.Tests
+{
+    public class ExpressionNotSupportedExceptionTests
+    {
+        [Fact]
+        public void Default_constructor()
+        {
+            var ex = new ExpressionNotSupportedException();
+
+            ex.Message.Should().Be("An expression is not supported.");
+            ex.InnerException.Should().BeNull();
+        }
+
+        [Fact]
+        public void Message_constructor()
+        {
+            var ex = new ExpressionNotSupportedException("custom message");
+
+            ex.Message.Should().Be("custom message");
+        }
+
+        [Fact]
+        public void Message_constructor_null_throws()
+        {
+            FluentActions.Invoking(() => new ExpressionNotSupportedException((string)null!))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Expression_constructor()
+        {
+            Expression<Func<int>> expr = () => 42;
+
+            var ex = new ExpressionNotSupportedException(expr);
+
+            ex.Message.Should().Contain("is not supported");
+        }
+
+        [Fact]
+        public void Expression_constructor_null_throws()
+        {
+            FluentActions.Invoking(() => new ExpressionNotSupportedException((Expression)null!))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Expression_and_inner_constructor()
+        {
+            Expression<Func<int>> expr = () => 42;
+            var inner = new InvalidOperationException("inner");
+
+            var ex = new ExpressionNotSupportedException(expr, inner);
+
+            ex.Message.Should().Contain("is not supported");
+            ex.InnerException.Should().BeSameAs(inner);
+        }
+
+        [Fact]
+        public void Expression_and_inner_constructor_null_expression_throws()
+        {
+            FluentActions.Invoking(() => new ExpressionNotSupportedException((Expression)null!, new Exception()))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Expression_and_inner_constructor_null_inner_throws()
+        {
+            Expression<Func<int>> expr = () => 42;
+
+            FluentActions.Invoking(() => new ExpressionNotSupportedException(expr, null!))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void InnerException_constructor()
+        {
+            var inner = new InvalidOperationException("inner");
+
+            var ex = new ExpressionNotSupportedException(inner);
+
+            ex.Message.Should().Be("An expression is not supported.");
+            ex.InnerException.Should().BeSameAs(inner);
+        }
+
+        [Fact]
+        public void InnerException_constructor_null_throws()
+        {
+            FluentActions.Invoking(() => new ExpressionNotSupportedException((Exception)null!))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Unwrap_nested_ExpressionNotSupportedException_with_standard_message()
+        {
+            var deepInner = new InvalidOperationException("root cause");
+            var wrappedOnce = new ExpressionNotSupportedException(deepInner);
+
+            var ex = new ExpressionNotSupportedException(wrappedOnce);
+
+            ex.InnerException.Should().BeSameAs(deepInner);
+        }
+
+        [Fact]
+        public void Does_not_unwrap_ExpressionNotSupportedException_with_custom_message()
+        {
+            var inner = new ExpressionNotSupportedException("custom");
+
+            var ex = new ExpressionNotSupportedException(inner);
+
+            ex.InnerException.Should().BeSameAs(inner);
+        }
+    }
+}

--- a/test/Core.Tests/ExpressionParsing/ExpressionSemanticsTests.cs
+++ b/test/Core.Tests/ExpressionParsing/ExpressionSemanticsTests.cs
@@ -1,0 +1,201 @@
+using ExRam.Gremlinq.Core.ExpressionParsing;
+
+using FluentAssertions;
+
+namespace ExRam.Gremlinq.Core.Tests
+{
+    public class ExpressionSemanticsTests
+    {
+        [Fact]
+        public void Equals_Flip_returns_self()
+        {
+            EqualsExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(EqualsExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void NotEquals_Flip_returns_self()
+        {
+            NotEqualsExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(NotEqualsExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void LowerThan_Flip_returns_GreaterThan()
+        {
+            LowerThanExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(GreaterThanExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThan_Flip_returns_LowerThan()
+        {
+            GreaterThanExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(LowerThanExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void LowerThanOrEqual_Flip_returns_GreaterThanOrEqual()
+        {
+            LowerThanOrEqualExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(GreaterThanOrEqualExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThanOrEqual_Flip_returns_LowerThanOrEqual()
+        {
+            GreaterThanOrEqualExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(LowerThanOrEqualExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void Contains_Flip_returns_IsContainedIn()
+        {
+            ContainsExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(IsContainedInExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void IsContainedIn_Flip_returns_Contains()
+        {
+            IsContainedInExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(ContainsExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void Intersects_Flip_returns_self()
+        {
+            IntersectsExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(IntersectsExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void True_Flip_returns_self()
+        {
+            TrueExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(TrueExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void False_Flip_returns_self()
+        {
+            FalseExpressionSemantics.Instance.Flip()
+                .Should().BeSameAs(FalseExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void HasInfix_Flip_returns_IsInfixOf_CaseSensitive()
+        {
+            HasInfixExpressionSemantics.CaseSensitive.Flip()
+                .Should().BeSameAs(IsInfixOfExpressionSemantics.CaseSensitive);
+        }
+
+        [Fact]
+        public void HasInfix_Flip_returns_IsInfixOf_CaseInsensitive()
+        {
+            HasInfixExpressionSemantics.CaseInsensitive.Flip()
+                .Should().BeSameAs(IsInfixOfExpressionSemantics.CaseInsensitive);
+        }
+
+        [Fact]
+        public void IsInfixOf_Flip_returns_HasInfix()
+        {
+            IsInfixOfExpressionSemantics.CaseSensitive.Flip()
+                .Should().BeSameAs(HasInfixExpressionSemantics.CaseSensitive);
+        }
+
+        [Fact]
+        public void StartsWith_Flip_returns_IsPrefixOf()
+        {
+            StartsWithExpressionSemantics.CaseSensitive.Flip()
+                .Should().BeSameAs(IsPrefixOfExpressionSemantics.CaseSensitive);
+        }
+
+        [Fact]
+        public void IsPrefixOf_Flip_returns_StartsWith()
+        {
+            IsPrefixOfExpressionSemantics.CaseInsensitive.Flip()
+                .Should().BeSameAs(StartsWithExpressionSemantics.CaseInsensitive);
+        }
+
+        [Fact]
+        public void EndsWith_Flip_returns_IsSuffixOf()
+        {
+            EndsWithExpressionSemantics.CaseSensitive.Flip()
+                .Should().BeSameAs(IsSuffixOfExpressionSemantics.CaseSensitive);
+        }
+
+        [Fact]
+        public void IsSuffixOf_Flip_returns_EndsWith()
+        {
+            IsSuffixOfExpressionSemantics.CaseInsensitive.Flip()
+                .Should().BeSameAs(EndsWithExpressionSemantics.CaseInsensitive);
+        }
+
+        [Fact]
+        public void StringEquals_Flip_returns_self()
+        {
+            StringEqualsExpressionSemantics.CaseSensitive.Flip()
+                .Should().BeSameAs(StringEqualsExpressionSemantics.CaseSensitive);
+        }
+
+        [Fact]
+        public void StringSemantics_Comparison_property()
+        {
+            HasInfixExpressionSemantics.CaseSensitive.Comparison
+                .Should().Be(StringComparison.Ordinal);
+
+            HasInfixExpressionSemantics.CaseInsensitive.Comparison
+                .Should().Be(StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void StringEquals_Get_unsupported_comparison_throws()
+        {
+            FluentActions.Invoking(() => StringEqualsExpressionSemantics.Get(StringComparison.CurrentCulture))
+                .Should().Throw<ExpressionNotSupportedException>();
+        }
+
+        [Fact]
+        public void HasInfix_Get_unsupported_comparison_throws()
+        {
+            FluentActions.Invoking(() => HasInfixExpressionSemantics.Get(StringComparison.CurrentCulture))
+                .Should().Throw<ExpressionNotSupportedException>();
+        }
+
+        [Fact]
+        public void StartsWith_Get_unsupported_comparison_throws()
+        {
+            FluentActions.Invoking(() => StartsWithExpressionSemantics.Get(StringComparison.InvariantCulture))
+                .Should().Throw<ExpressionNotSupportedException>();
+        }
+
+        [Fact]
+        public void EndsWith_Get_unsupported_comparison_throws()
+        {
+            FluentActions.Invoking(() => EndsWithExpressionSemantics.Get(StringComparison.InvariantCultureIgnoreCase))
+                .Should().Throw<ExpressionNotSupportedException>();
+        }
+
+        [Fact]
+        public void IsInfixOf_Get_unsupported_comparison_throws()
+        {
+            FluentActions.Invoking(() => IsInfixOfExpressionSemantics.Get(StringComparison.CurrentCulture))
+                .Should().Throw<ExpressionNotSupportedException>();
+        }
+
+        [Fact]
+        public void IsPrefixOf_Get_unsupported_comparison_throws()
+        {
+            FluentActions.Invoking(() => IsPrefixOfExpressionSemantics.Get(StringComparison.CurrentCulture))
+                .Should().Throw<ExpressionNotSupportedException>();
+        }
+
+        [Fact]
+        public void IsSuffixOf_Get_unsupported_comparison_throws()
+        {
+            FluentActions.Invoking(() => IsSuffixOfExpressionSemantics.Get(StringComparison.CurrentCulture))
+                .Should().Throw<ExpressionNotSupportedException>();
+        }
+    }
+}

--- a/test/Core.Tests/ExpressionParsing/TransformCompareToTests.cs
+++ b/test/Core.Tests/ExpressionParsing/TransformCompareToTests.cs
@@ -1,0 +1,177 @@
+using ExRam.Gremlinq.Core.ExpressionParsing;
+
+using FluentAssertions;
+
+namespace ExRam.Gremlinq.Core.Tests
+{
+    public class TransformCompareToTests
+    {
+        [Fact]
+        public void LowerThan_compareTo_0_returns_LowerThan()
+        {
+            LowerThanExpressionSemantics.Instance.TransformCompareTo(0)
+                .Should().BeSameAs(LowerThanExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void LowerThan_compareTo_1_returns_LowerThanOrEqual()
+        {
+            LowerThanExpressionSemantics.Instance.TransformCompareTo(1)
+                .Should().BeSameAs(LowerThanOrEqualExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void LowerThan_compareTo_2_returns_True()
+        {
+            LowerThanExpressionSemantics.Instance.TransformCompareTo(2)
+                .Should().BeSameAs(TrueExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void LowerThan_compareTo_neg1_returns_False()
+        {
+            LowerThanExpressionSemantics.Instance.TransformCompareTo(-1)
+                .Should().BeSameAs(FalseExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void LowerThanOrEqual_compareTo_neg1_returns_LowerThan()
+        {
+            LowerThanOrEqualExpressionSemantics.Instance.TransformCompareTo(-1)
+                .Should().BeSameAs(LowerThanExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void LowerThanOrEqual_compareTo_0_returns_LowerThanOrEqual()
+        {
+            LowerThanOrEqualExpressionSemantics.Instance.TransformCompareTo(0)
+                .Should().BeSameAs(LowerThanOrEqualExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void LowerThanOrEqual_compareTo_1_returns_True()
+        {
+            LowerThanOrEqualExpressionSemantics.Instance.TransformCompareTo(1)
+                .Should().BeSameAs(TrueExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void LowerThanOrEqual_compareTo_neg2_returns_False()
+        {
+            LowerThanOrEqualExpressionSemantics.Instance.TransformCompareTo(-2)
+                .Should().BeSameAs(FalseExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void Equals_compareTo_neg1_returns_LowerThan()
+        {
+            EqualsExpressionSemantics.Instance.TransformCompareTo(-1)
+                .Should().BeSameAs(LowerThanExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void Equals_compareTo_0_returns_Equals()
+        {
+            EqualsExpressionSemantics.Instance.TransformCompareTo(0)
+                .Should().BeSameAs(EqualsExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void Equals_compareTo_1_returns_GreaterThan()
+        {
+            EqualsExpressionSemantics.Instance.TransformCompareTo(1)
+                .Should().BeSameAs(GreaterThanExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void Equals_compareTo_2_returns_False()
+        {
+            EqualsExpressionSemantics.Instance.TransformCompareTo(2)
+                .Should().BeSameAs(FalseExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThanOrEqual_compareTo_neg1_returns_True()
+        {
+            GreaterThanOrEqualExpressionSemantics.Instance.TransformCompareTo(-1)
+                .Should().BeSameAs(TrueExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThanOrEqual_compareTo_0_returns_GreaterThanOrEqual()
+        {
+            GreaterThanOrEqualExpressionSemantics.Instance.TransformCompareTo(0)
+                .Should().BeSameAs(GreaterThanOrEqualExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThanOrEqual_compareTo_1_returns_GreaterThan()
+        {
+            GreaterThanOrEqualExpressionSemantics.Instance.TransformCompareTo(1)
+                .Should().BeSameAs(GreaterThanExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThanOrEqual_compareTo_2_returns_False()
+        {
+            GreaterThanOrEqualExpressionSemantics.Instance.TransformCompareTo(2)
+                .Should().BeSameAs(FalseExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThan_compareTo_neg2_returns_True()
+        {
+            GreaterThanExpressionSemantics.Instance.TransformCompareTo(-2)
+                .Should().BeSameAs(TrueExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThan_compareTo_neg1_returns_GreaterThanOrEqual()
+        {
+            GreaterThanExpressionSemantics.Instance.TransformCompareTo(-1)
+                .Should().BeSameAs(GreaterThanOrEqualExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThan_compareTo_0_returns_GreaterThan()
+        {
+            GreaterThanExpressionSemantics.Instance.TransformCompareTo(0)
+                .Should().BeSameAs(GreaterThanExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void GreaterThan_compareTo_1_returns_False()
+        {
+            GreaterThanExpressionSemantics.Instance.TransformCompareTo(1)
+                .Should().BeSameAs(FalseExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void NotEquals_compareTo_neg1_returns_GreaterThanOrEqual()
+        {
+            NotEqualsExpressionSemantics.Instance.TransformCompareTo(-1)
+                .Should().BeSameAs(GreaterThanOrEqualExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void NotEquals_compareTo_0_returns_NotEquals()
+        {
+            NotEqualsExpressionSemantics.Instance.TransformCompareTo(0)
+                .Should().BeSameAs(NotEqualsExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void NotEquals_compareTo_1_returns_LowerThanOrEqual()
+        {
+            NotEqualsExpressionSemantics.Instance.TransformCompareTo(1)
+                .Should().BeSameAs(LowerThanOrEqualExpressionSemantics.Instance);
+        }
+
+        [Fact]
+        public void NotEquals_compareTo_2_returns_True()
+        {
+            NotEqualsExpressionSemantics.Instance.TransformCompareTo(2)
+                .Should().BeSameAs(TrueExpressionSemantics.Instance);
+        }
+    }
+}

--- a/test/Providers.Core.Tests/ClientWrapperTests.cs
+++ b/test/Providers.Core.Tests/ClientWrapperTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+
+using Gremlin.Net.Driver.Messages;
+
+using NSubstitute;
+
+namespace ExRam.Gremlinq.Providers.Core.Tests
+{
+    public class ClientWrapperTests
+    {
+        [Fact]
+        public void TransformRequest_dispose_propagates()
+        {
+            var inner = Substitute.For<IGremlinqClient>();
+
+            var wrapped = inner.TransformRequest((msg, ct) => Task.FromResult(msg));
+            wrapped.Dispose();
+
+            inner.Received(1).Dispose();
+        }
+
+        [Fact]
+        public void ObserveResultStatusAttributes_dispose_propagates()
+        {
+            var inner = Substitute.For<IGremlinqClient>();
+
+            var wrapped = inner.ObserveResultStatusAttributes((_, _) => { });
+            wrapped.Dispose();
+
+            inner.Received(1).Dispose();
+        }
+
+        [Fact]
+        public void Throttle_dispose_propagates()
+        {
+            var inner = Substitute.For<IGremlinqClient>();
+
+            var wrapped = inner.Throttle(4);
+            wrapped.Dispose();
+
+            inner.Received(1).Dispose();
+        }
+
+        [Fact]
+        public void TransformRequest_null_client_throws()
+        {
+            FluentActions.Invoking(() => GremlinqClientExtensions.TransformRequest(null!, (msg, ct) => Task.FromResult(msg)))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void TransformRequest_null_transformation_throws()
+        {
+            var inner = Substitute.For<IGremlinqClient>();
+
+            FluentActions.Invoking(() => inner.TransformRequest(null!))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ObserveResultStatusAttributes_null_client_throws()
+        {
+            FluentActions.Invoking(() => GremlinqClientExtensions.ObserveResultStatusAttributes(null!, (_, _) => { }))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ObserveResultStatusAttributes_null_observer_throws()
+        {
+            var inner = Substitute.For<IGremlinqClient>();
+
+            FluentActions.Invoking(() => inner.ObserveResultStatusAttributes(null!))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Throttle_null_client_throws()
+        {
+            FluentActions.Invoking(() => GremlinqClientExtensions.Throttle(null!, 4))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/test/Providers.Core.Tests/PoolConfigurationTests.cs
+++ b/test/Providers.Core.Tests/PoolConfigurationTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+
+using NSubstitute;
+
+namespace ExRam.Gremlinq.Providers.Core.Tests
+{
+    public class PoolConfigurationTests
+    {
+        [Fact]
+        public void WithPoolSize_zero_throws()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory>().Pool();
+
+            factory
+                .Invoking(f => f.WithPoolSize(0))
+                .Should()
+                .Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WithPoolSize_negative_throws()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory>().Pool();
+
+            factory
+                .Invoking(f => f.WithPoolSize(-1))
+                .Should()
+                .Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WithPoolSize_nine_throws()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory>().Pool();
+
+            factory
+                .Invoking(f => f.WithPoolSize(9))
+                .Should()
+                .Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WithPoolSize_valid_values()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory>().Pool();
+
+            for (var i = 1; i <= 8; i++)
+            {
+                factory
+                    .Invoking(f => f.WithPoolSize(i))
+                    .Should()
+                    .NotThrow();
+            }
+        }
+
+        [Fact]
+        public void WithMaxInProcessPerConnection_zero_throws()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory>().Pool();
+
+            factory
+                .Invoking(f => f.WithMaxInProcessPerConnection(0))
+                .Should()
+                .Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WithMaxInProcessPerConnection_negative_throws()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory>().Pool();
+
+            factory
+                .Invoking(f => f.WithMaxInProcessPerConnection(-1))
+                .Should()
+                .Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WithMaxInProcessPerConnection_65_throws()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory>().Pool();
+
+            factory
+                .Invoking(f => f.WithMaxInProcessPerConnection(65))
+                .Should()
+                .Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WithMaxInProcessPerConnection_valid_values()
+        {
+            var factory = Substitute.For<IGremlinqClientFactory>().Pool();
+
+            factory
+                .Invoking(f => f.WithMaxInProcessPerConnection(1))
+                .Should()
+                .NotThrow();
+
+            factory
+                .Invoking(f => f.WithMaxInProcessPerConnection(64))
+                .Should()
+                .NotThrow();
+        }
+    }
+}

--- a/test/Providers.CosmosDb.Tests/CosmosDbKeyTests.cs
+++ b/test/Providers.CosmosDb.Tests/CosmosDbKeyTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+
+namespace ExRam.Gremlinq.Providers.CosmosDb.Tests
+{
+    public class CosmosDbKeyTests
+    {
+        [Fact]
+        public void Equality_same_id()
+        {
+            var value1 = "id1";
+            var value2 = "id1234".Substring(0, 3);
+
+            ReferenceEquals(value1, value2).Should().BeFalse();
+
+            var key1 = new CosmosDbKey(value1);
+            var key2 = new CosmosDbKey(value2);
+
+            key1.Equals(key2).Should().BeTrue();
+            (key1 == key2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Equality_same_partition_and_id()
+        {
+            var key1 = new CosmosDbKey("pk", "id");
+            var key2 = new CosmosDbKey("pk", "id");
+
+            key1.Equals(key2).Should().BeTrue();
+            (key1 == key2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Inequality_different_id()
+        {
+            var key1 = new CosmosDbKey("id1");
+            var key2 = new CosmosDbKey("id2");
+
+            (key1 != key2).Should().BeTrue();
+            (key1 == key2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Inequality_different_partition()
+        {
+            var key1 = new CosmosDbKey("pk1", "id");
+            var key2 = new CosmosDbKey("pk2", "id");
+
+            (key1 != key2).Should().BeTrue();
+            key1.Equals(key2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Inequality_with_and_without_partition()
+        {
+            var key1 = new CosmosDbKey("id");
+            var key2 = new CosmosDbKey("pk", "id");
+
+            key1.Equals(key2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetHashCode_equal_for_equal_keys()
+        {
+            var key1 = new CosmosDbKey("pk", "id");
+            var key2 = new CosmosDbKey("pk", "id");
+
+            key1.GetHashCode().Should().Be(key2.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_different_for_different_keys()
+        {
+            var key1 = new CosmosDbKey("pk1", "id1");
+            var key2 = new CosmosDbKey("pk2", "id2");
+
+            key1.GetHashCode().Should().NotBe(key2.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_object_returns_false_for_non_CosmosDbKey()
+        {
+            var key = new CosmosDbKey("id");
+
+            key.Equals("id").Should().BeFalse();
+            key.Equals(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Default_struct_Id_throws()
+        {
+            var key = default(CosmosDbKey);
+
+            key
+                .Invoking(k => _ = k.Id)
+                .Should()
+                .Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void Constructor_with_null_id_throws()
+        {
+            FluentActions.Invoking(() => new CosmosDbKey(null!))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Constructor_with_null_partitionKey_throws()
+        {
+            FluentActions.Invoking(() => new CosmosDbKey(null!, "id"))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Constructor_with_null_id_and_partition_throws()
+        {
+            FluentActions.Invoking(() => new CosmosDbKey("pk", null!))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Id_returns_value()
+        {
+            new CosmosDbKey("myId").Id.Should().Be("myId");
+        }
+
+        [Fact]
+        public void PartitionKey_returns_value()
+        {
+            new CosmosDbKey("pk", "id").PartitionKey.Should().Be("pk");
+        }
+
+        [Fact]
+        public void PartitionKey_is_null_without_partition()
+        {
+            new CosmosDbKey("id").PartitionKey.Should().BeNull();
+        }
+    }
+}

--- a/test/Providers.GremlinServer.AspNet.Tests/WebSocketConfigurationTests.cs
+++ b/test/Providers.GremlinServer.AspNet.Tests/WebSocketConfigurationTests.cs
@@ -1,0 +1,105 @@
+using ExRam.Gremlinq.Core;
+using ExRam.Gremlinq.Core.AspNet;
+using ExRam.Gremlinq.Tests.Entities;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExRam.Gremlinq.Providers.GremlinServer.AspNet.Tests
+{
+    public class WebSocketConfigurationTests
+    {
+        [Fact]
+        public void With_pool_size() => new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "Gremlinq:GremlinServer:Uri", "ws://localhost:8182/" },
+                    { "Gremlinq:GremlinServer:ConnectionPool:PoolSize", "4" },
+                })
+                .Build())
+            .AddGremlinq(setup => setup
+                .UseGremlinServer<Vertex, Edge>())
+            .BuildServiceProvider()
+            .GetRequiredService<IGremlinQuerySource>()
+            .Should()
+            .NotBeNull();
+
+        [Fact]
+        public void With_max_in_process_per_connection() => new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "Gremlinq:GremlinServer:Uri", "ws://localhost:8182/" },
+                    { "Gremlinq:GremlinServer:ConnectionPool:MaxInProcessPerConnection", "16" },
+                })
+                .Build())
+            .AddGremlinq(setup => setup
+                .UseGremlinServer<Vertex, Edge>())
+            .BuildServiceProvider()
+            .GetRequiredService<IGremlinQuerySource>()
+            .Should()
+            .NotBeNull();
+
+        [Fact]
+        public void With_pool_size_and_max_in_process() => new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "Gremlinq:GremlinServer:Uri", "ws://localhost:8182/" },
+                    { "Gremlinq:GremlinServer:ConnectionPool:PoolSize", "4" },
+                    { "Gremlinq:GremlinServer:ConnectionPool:MaxInProcessPerConnection", "16" },
+                })
+                .Build())
+            .AddGremlinq(setup => setup
+                .UseGremlinServer<Vertex, Edge>())
+            .BuildServiceProvider()
+            .GetRequiredService<IGremlinQuerySource>()
+            .Should()
+            .NotBeNull();
+
+        [Fact]
+        public void Without_uri() => new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>())
+                .Build())
+            .AddGremlinq(setup => setup
+                .UseGremlinServer<Vertex, Edge>())
+            .BuildServiceProvider()
+            .GetRequiredService<IGremlinQuerySource>()
+            .Should()
+            .NotBeNull();
+
+        [Fact]
+        public void With_authentication_without_password() => new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "Gremlinq:GremlinServer:Authentication:Username", "user" },
+                })
+                .Build())
+            .AddGremlinq(setup => setup
+                .UseGremlinServer<Vertex, Edge>())
+            .BuildServiceProvider()
+            .GetRequiredService<IGremlinQuerySource>()
+            .Should()
+            .NotBeNull();
+
+        [Fact]
+        public void With_authentication_without_username() => new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "Gremlinq:GremlinServer:Authentication:Password", "pass" },
+                })
+                .Build())
+            .AddGremlinq(setup => setup
+                .UseGremlinServer<Vertex, Edge>())
+            .BuildServiceProvider()
+            .GetRequiredService<IGremlinQuerySource>()
+            .Should()
+            .NotBeNull();
+    }
+}

--- a/test/Providers.Neptune.Tests/ExceptionExtensionsEdgeCaseTests.cs
+++ b/test/Providers.Neptune.Tests/ExceptionExtensionsEdgeCaseTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Immutable;
+
+using ExRam.Gremlinq.Core;
+using ExRam.Gremlinq.Core.Execution;
+
+using FluentAssertions;
+
+using Gremlin.Net.Driver.Exceptions;
+using Gremlin.Net.Driver.Messages;
+
+namespace ExRam.Gremlinq.Providers.Neptune.Tests
+{
+    public class ExceptionExtensionsEdgeCaseTests
+    {
+        private static GremlinQueryExecutionException CreateException(Exception? inner = null) =>
+            new(GremlinQueryExecutionContext.Create(GremlinQuerySource.g.Inject(42)), inner ?? new Exception());
+
+        [Fact]
+        public void Non_ResponseException_returns_null()
+        {
+            var ex = CreateException(new InvalidOperationException("not a response exception"));
+
+            ex.TryGetNeptuneGremlinQueryExecutionException()
+                .Should().BeNull();
+        }
+
+        [Fact]
+        public void ResponseException_with_invalid_json_returns_null()
+        {
+            var ex = CreateException(new ResponseException(
+                ResponseStatusCode.ServerError,
+                ImmutableDictionary<string, object>.Empty,
+                "ServerError: this is not valid json"));
+
+            ex.TryGetNeptuneGremlinQueryExecutionException()
+                .Should().BeNull();
+        }
+
+        [Fact]
+        public void ResponseException_without_code_returns_null()
+        {
+            var ex = CreateException(new ResponseException(
+                ResponseStatusCode.ServerError,
+                ImmutableDictionary<string, object>.Empty,
+                """ServerError: {"detailedMessage":"some detail","requestId":"abc"}"""));
+
+            ex.TryGetNeptuneGremlinQueryExecutionException()
+                .Should().BeNull();
+        }
+
+        [Fact]
+        public void ResponseException_with_empty_code_returns_null()
+        {
+            var ex = CreateException(new ResponseException(
+                ResponseStatusCode.ServerError,
+                ImmutableDictionary<string, object>.Empty,
+                """ServerError: {"code":"","detailedMessage":"detail","requestId":"abc"}"""));
+
+            ex.TryGetNeptuneGremlinQueryExecutionException()
+                .Should().BeNull();
+        }
+
+        [Fact]
+        public void ResponseException_message_equals_status_code_only_returns_null()
+        {
+            var ex = CreateException(new ResponseException(
+                ResponseStatusCode.ServerError,
+                ImmutableDictionary<string, object>.Empty,
+                "ServerError"));
+
+            ex.TryGetNeptuneGremlinQueryExecutionException()
+                .Should().BeNull();
+        }
+
+        [Fact]
+        public void UseDFE_null_source_throws()
+        {
+            FluentActions.Invoking(() => GremlinQuerySourceExtensions.UseDFE(null!))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void UseDFE_enabled_returns_source()
+        {
+            GremlinQuerySource.g.UseDFE()
+                .Should().NotBeNull();
+        }
+
+        [Fact]
+        public void UseDFE_disabled_returns_source()
+        {
+            GremlinQuerySource.g.UseDFE(false)
+                .Should().NotBeNull();
+        }
+    }
+}

--- a/test/Support.NewtonsoftJson.Tests/DynamicDictionaryTests.cs
+++ b/test/Support.NewtonsoftJson.Tests/DynamicDictionaryTests.cs
@@ -1,0 +1,295 @@
+using System.Dynamic;
+
+using ExRam.Gremlinq.Core;
+using ExRam.Gremlinq.Core.Models;
+using ExRam.Gremlinq.Tests.Entities;
+
+using FluentAssertions;
+
+using Newtonsoft.Json.Linq;
+
+namespace ExRam.Gremlinq.Support.NewtonsoftJson.Tests
+{
+    public class DynamicDictionaryTests
+    {
+        private readonly IGremlinQueryEnvironment _environment;
+
+        public DynamicDictionaryTests()
+        {
+            _environment = GremlinQueryEnvironment.Invalid
+                .UseModel(GraphModel.FromBaseTypes<Vertex, Edge>())
+                .UseNewtonsoftJson();
+        }
+
+        private dynamic GetDynamic(string json = "{ \"name\": \"test\", \"age\": 42 }")
+        {
+            var jObject = JObject.Parse(json);
+
+            return _environment
+                .Deserializer
+                .TryTransformTo<object>().From(jObject, _environment)!;
+        }
+
+        [Fact]
+        public void Is_DynamicObject()
+        {
+            var result = GetDynamic();
+
+            ((object)result).Should().BeAssignableTo<DynamicObject>();
+        }
+
+        [Fact]
+        public void Is_IReadOnlyDictionary()
+        {
+            var result = GetDynamic();
+
+            ((object)result).Should().BeAssignableTo<IReadOnlyDictionary<string, object?>>();
+        }
+
+        [Fact]
+        public void Is_IDictionary()
+        {
+            var result = GetDynamic();
+
+            ((object)result).Should().BeAssignableTo<IDictionary<string, object?>>();
+        }
+
+        [Fact]
+        public void ReadOnly_Keys()
+        {
+            IReadOnlyDictionary<string, object?> dict = GetDynamic();
+
+            dict.Keys.Should().Contain("name").And.Contain("age");
+        }
+
+        [Fact]
+        public void ReadOnly_Values()
+        {
+            IReadOnlyDictionary<string, object?> dict = GetDynamic();
+
+            dict.Values.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void ReadOnly_Count()
+        {
+            IReadOnlyDictionary<string, object?> dict = GetDynamic();
+
+            dict.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void ReadOnly_Indexer()
+        {
+            IReadOnlyDictionary<string, object?> dict = GetDynamic();
+
+            dict["name"].Should().Be("test");
+        }
+
+        [Fact]
+        public void ReadOnly_ContainsKey()
+        {
+            IReadOnlyDictionary<string, object?> dict = GetDynamic();
+
+            dict.ContainsKey("name").Should().BeTrue();
+            dict.ContainsKey("nonexistent").Should().BeFalse();
+        }
+
+        [Fact]
+        public void ReadOnly_TryGetValue()
+        {
+            IReadOnlyDictionary<string, object?> dict = GetDynamic();
+
+            dict.TryGetValue("name", out var value).Should().BeTrue();
+            value.Should().Be("test");
+
+            dict.TryGetValue("nonexistent", out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public void ReadOnly_GetEnumerator()
+        {
+            IReadOnlyDictionary<string, object?> dict = GetDynamic();
+
+            var items = dict.ToList();
+            items.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Mutable_Keys()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+
+            dict.Keys.Should().Contain("name").And.Contain("age");
+        }
+
+        [Fact]
+        public void Mutable_Values()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+
+            dict.Values.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Mutable_Count()
+        {
+            ICollection<KeyValuePair<string, object?>> collection = GetDynamic();
+
+            collection.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void Mutable_IsReadOnly()
+        {
+            ICollection<KeyValuePair<string, object?>> collection = GetDynamic();
+
+            collection.IsReadOnly.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Mutable_Indexer_get()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+
+            dict["name"].Should().Be("test");
+        }
+
+        [Fact]
+        public void Mutable_Indexer_set()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+
+            dict["name"] = "updated";
+            dict["name"].Should().Be("updated");
+        }
+
+        [Fact]
+        public void Mutable_Add()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+
+            dict.Add("newKey", "newValue");
+            dict["newKey"].Should().Be("newValue");
+        }
+
+        [Fact]
+        public void Mutable_ContainsKey()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+
+            dict.ContainsKey("name").Should().BeTrue();
+            dict.ContainsKey("nonexistent").Should().BeFalse();
+        }
+
+        [Fact]
+        public void Mutable_Remove()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+
+            dict.Remove("name").Should().BeTrue();
+            dict.ContainsKey("name").Should().BeFalse();
+        }
+
+        [Fact]
+        public void Mutable_TryGetValue()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+
+            dict.TryGetValue("name", out var value).Should().BeTrue();
+            value.Should().Be("test");
+
+            dict.TryGetValue("nonexistent", out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Collection_Add_pair()
+        {
+            ICollection<KeyValuePair<string, object?>> collection = GetDynamic();
+
+            collection.Add(new KeyValuePair<string, object?>("extra", "val"));
+            collection.Count.Should().Be(3);
+        }
+
+        [Fact]
+        public void Collection_Clear()
+        {
+            ICollection<KeyValuePair<string, object?>> collection = GetDynamic();
+
+            collection.Clear();
+            collection.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void Collection_Contains()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+            ICollection<KeyValuePair<string, object?>> collection = (ICollection<KeyValuePair<string, object?>>)dict;
+
+            collection.Contains(new KeyValuePair<string, object?>("name", "test")).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Collection_CopyTo()
+        {
+            ICollection<KeyValuePair<string, object?>> collection = GetDynamic();
+
+            var array = new KeyValuePair<string, object?>[2];
+            collection.CopyTo(array, 0);
+
+            array.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Collection_Remove_pair()
+        {
+            IDictionary<string, object?> dict = GetDynamic();
+            ICollection<KeyValuePair<string, object?>> collection = (ICollection<KeyValuePair<string, object?>>)dict;
+
+            collection.Remove(new KeyValuePair<string, object?>("name", "test")).Should().BeTrue();
+        }
+
+        [Fact]
+        public void NonGeneric_GetEnumerator()
+        {
+            var result = GetDynamic();
+            var enumerable = (System.Collections.IEnumerable)result;
+
+            var enumerator = enumerable.GetEnumerator();
+            enumerator.MoveNext().Should().BeTrue();
+        }
+
+        [Fact]
+        public void Dynamic_TrySetMember()
+        {
+            dynamic result = GetDynamic();
+
+            result.newProp = "hello";
+
+            IDictionary<string, object?> dict = result;
+            dict["newProp"].Should().Be("hello");
+        }
+
+        [Fact]
+        public void Dynamic_TryGetMember()
+        {
+            dynamic result = GetDynamic();
+
+            string name = result.name;
+            name.Should().Be("test");
+        }
+
+        [Fact]
+        public void Dynamic_TryGetMember_nonexistent()
+        {
+            dynamic result = GetDynamic();
+
+            FluentActions.Invoking(() =>
+            {
+                object? _ = result.nonexistent;
+            })
+            .Should()
+            .Throw<Microsoft.CSharp.RuntimeBinder.RuntimeBinderException>();
+        }
+    }
+}

--- a/test/Support.NewtonsoftJson.Tests/JTokenHeuristicTests.cs
+++ b/test/Support.NewtonsoftJson.Tests/JTokenHeuristicTests.cs
@@ -1,0 +1,231 @@
+using ExRam.Gremlinq.Core;
+using ExRam.Gremlinq.Core.Models;
+using ExRam.Gremlinq.Core.Transformation;
+using ExRam.Gremlinq.Tests.Entities;
+
+using FluentAssertions;
+
+using Newtonsoft.Json.Linq;
+
+namespace ExRam.Gremlinq.Support.NewtonsoftJson.Tests
+{
+    public class JTokenHeuristicTests
+    {
+        private readonly IGremlinQueryEnvironment _environment;
+
+        public JTokenHeuristicTests()
+        {
+            _environment = GremlinQueryEnvironment.Invalid
+                .UseModel(GraphModel.FromBaseTypes<Vertex, Edge>())
+                .UseNewtonsoftJson();
+        }
+
+        [Fact]
+        public void LooksLikeElement_with_id_and_label()
+        {
+            var jObject = JObject.Parse("""{ "id": 1, "label": "person" }""");
+
+            jObject.LooksLikeElement(out var idToken, out var labelValue, out var propertiesObject)
+                .Should().BeTrue();
+
+            idToken.Should().NotBeNull();
+            labelValue!.Value<string>().Should().Be("person");
+            propertiesObject.Should().BeNull();
+        }
+
+        [Fact]
+        public void LooksLikeElement_with_properties()
+        {
+            var jObject = JObject.Parse("""{ "id": 1, "label": "person", "properties": { "name": "test" } }""");
+
+            jObject.LooksLikeElement(out _, out _, out var propertiesObject)
+                .Should().BeTrue();
+
+            propertiesObject.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void LooksLikeElement_without_id_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "label": "person" }""");
+
+            jObject.LooksLikeElement(out _, out _, out _)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeElement_without_label_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "id": 1 }""");
+
+            jObject.LooksLikeElement(out _, out _, out _)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeElement_with_value_key_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "id": 1, "label": "person", "value": "something" }""");
+
+            jObject.LooksLikeElement(out _, out _, out _)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeElement_with_array_id_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "id": [1, 2], "label": "person" }""");
+
+            jObject.LooksLikeElement(out _, out _, out _)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeElement_with_non_string_label_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "id": 1, "label": 123 }""");
+
+            jObject.LooksLikeElement(out _, out _, out _)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeElement_with_non_object_properties_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "id": 1, "label": "person", "properties": "not-object" }""");
+
+            jObject.LooksLikeElement(out _, out _, out _)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeProperty_with_value_and_key()
+        {
+            var jObject = JObject.Parse("""{ "value": "test", "key": "name" }""");
+
+            jObject.LooksLikeProperty()
+                .Should().BeTrue();
+        }
+
+        [Fact]
+        public void LooksLikeProperty_without_value_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "key": "name" }""");
+
+            jObject.LooksLikeProperty()
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeProperty_without_key_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "value": "test" }""");
+
+            jObject.LooksLikeProperty()
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeProperty_with_non_string_key_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "value": "test", "key": 123 }""");
+
+            jObject.LooksLikeProperty()
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeVertexProperty_with_value_and_id()
+        {
+            var jObject = JObject.Parse("""{ "value": "test", "id": 1 }""");
+
+            jObject.LooksLikeVertexProperty()
+                .Should().BeTrue();
+        }
+
+        [Fact]
+        public void LooksLikeVertexProperty_with_label_and_properties()
+        {
+            var jObject = JObject.Parse("""{ "value": "test", "id": 1, "label": "name", "properties": { "p": 1 } }""");
+
+            jObject.LooksLikeVertexProperty()
+                .Should().BeTrue();
+        }
+
+        [Fact]
+        public void LooksLikeVertexProperty_without_value_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "id": 1 }""");
+
+            jObject.LooksLikeVertexProperty()
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeVertexProperty_without_id_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "value": "test" }""");
+
+            jObject.LooksLikeVertexProperty()
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeVertexProperty_with_array_id_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "value": "test", "id": [1, 2] }""");
+
+            jObject.LooksLikeVertexProperty()
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeVertexProperty_with_non_string_label_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "value": "test", "id": 1, "label": 123 }""");
+
+            jObject.LooksLikeVertexProperty()
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void LooksLikeVertexProperty_with_non_object_properties_returns_false()
+        {
+            var jObject = JObject.Parse("""{ "value": "test", "id": 1, "properties": "not-object" }""");
+
+            jObject.LooksLikeVertexProperty()
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void TryExpandTraverser_non_traverser_returns_null()
+        {
+            var jObject = JObject.Parse("""{ "name": "test" }""");
+
+            jObject.TryExpandTraverser<object>(_environment, _environment.Deserializer)
+                .Should().BeNull();
+        }
+
+        [Fact]
+        public void TryExpandTraverser_valid_traverser()
+        {
+            var jObject = JObject.Parse("""{ "@type": "g:Traverser", "@value": { "bulk": { "@type": "g:Int64", "@value": 2 }, "value": "hello" } }""");
+
+            var result = jObject.TryExpandTraverser<object>(_environment, _environment.Deserializer);
+
+            result.Should().NotBeNull();
+            result!.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void TryExpandTraverser_null_value_yields_defaults()
+        {
+            var jObject = JObject.Parse("""{ "@type": "g:Traverser", "@value": { "bulk": { "@type": "g:Int64", "@value": 1 }, "value": null } }""");
+
+            var result = jObject.TryExpandTraverser<string>(_environment, _environment.Deserializer);
+
+            result.Should().NotBeNull();
+            result!.Should().ContainSingle().Which.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
- CosmosDbKey: equality, inequality, GetHashCode, constructors, properties
- Providers.Core: PoolGremlinqClientFactory boundary validation (WithPoolSize, WithMaxInProcessPerConnection), client wrapper Dispose propagation, null argument checks
- Core.AspNet: GremlinqConfigurationSection GetChildren/GetReloadToken/Indexer/Value/Key/Path/GetSection, GremlinqServicesBuilder ConfigureQuerySource/FromBaseSection
- GremlinServer.AspNet: WebSocket ConnectionPool config (PoolSize, MaxInProcessPerConnection), partial auth config (username-only, password-only)
- NewtonsoftJson: DynamicDictionary IReadOnlyDictionary/IDictionary/ICollection interface members, DynamicObject TrySetMember/TryGetMember
- ExpressionSemanticsTests: 26 tests for Flip() across all semantics types and StringSemantics.Get() error paths
- TransformCompareToTests: 24 tests covering all branches of ObjectExpressionSemantics.TransformCompareTo
- ExpressionNotSupportedExceptionTests: 12 tests for all constructors, null validation, and Unwrap behavior
- ElementTests: 19 tests for Property<T>, VertexProperty<T>, VertexProperty<T,TMeta>, and Path
- ExceptionExtensionsEdgeCaseTests: 8 tests for Neptune exception edge cases and UseDFE extension
- JTokenHeuristicTests: 22 tests for LooksLikeElement, LooksLikeProperty, LooksLikeVertexProperty, TryExpandTraverser